### PR TITLE
fix: 更新日志中的超链接跳转由新窗口打开

### DIFF
--- a/src/components/List/CoverList.vue
+++ b/src/components/List/CoverList.vue
@@ -363,7 +363,6 @@ const getListData = async (id: number): Promise<SongType[]> => {
     &:hover {
       background-color: rgba(var(--primary), 0.12);
       .cover {
-        border-radius: 16px 16px 0 0;
         .cover-img {
           transform: scale(1.1);
           filter: brightness(0.8);

--- a/src/components/Setting/AboutSetting.vue
+++ b/src/components/Setting/AboutSetting.vue
@@ -32,7 +32,7 @@
             </n-tag>
             <n-text :depth="3" class="time">{{ newVersion?.time }}</n-text>
           </n-flex>
-          <div class="markdown-body" v-html="newVersion?.changelog" />
+          <div class="markdown-body" v-html="newVersion?.changelog" @click="jumpLink" />
         </n-card>
       </n-collapse-transition>
     </div>
@@ -53,7 +53,7 @@
                 </n-tag>
                 <n-text :depth="3" class="time">{{ item?.time }}</n-text>
               </n-flex>
-              <div class="markdown-body" v-html="item?.changelog" />
+              <div class="markdown-body" v-html="item?.changelog" @click="jumpLink" />
             </n-card>
           </n-collapse-item>
         </n-collapse>
@@ -125,6 +125,16 @@ const checkUpdate = debounce(
   300,
   { leading: true, trailing: false },
 );
+
+// 链接跳转
+const jumpLink = (e: MouseEvent) => {
+  const target = e.target as HTMLElement;
+  if (target.tagName !== "A") {
+    return;
+  }
+  e.preventDefault();
+  openLink((target as HTMLAnchorElement).href);
+};
 
 // 获取更新日志
 const getUpdateData = async () => (updateData.value = await getUpdateLog());


### PR DESCRIPTION
- 在 AboutSetting 组件中添加了 jumpLink 函数，实现更新日志中链接的点击跳转  (#330) 
- 修复 CoverList 组件移入移出会出现黑角的bug 