### PR TITLE
Docker 镜像内置 UnblockNeteaseMusic,  支持播放部分无版权歌曲

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,16 @@ COPY --from=builder /app/out/renderer /usr/share/nginx/html
 
 COPY --from=builder /app/nginx.conf /etc/nginx/conf.d/default.conf
 
-RUN apk add --no-cache npm
+COPY --from=builder /app/docker-entrypoint.sh /docker-entrypoint.sh
 
-RUN npm install -g NeteaseCloudMusicApi
+RUN apk add --no-cache npm python3 youtube-dl \
+    && npm install -g @unblockneteasemusic/server NeteaseCloudMusicApi \
+    && wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp \
+    && chmod +x /usr/local/bin/yt-dlp \
+    && chmod +x /docker-entrypoint.sh
 
-CMD nginx && npx NeteaseCloudMusicApi
+ENV NODE_TLS_REJECT_UNAUTHORIZED=0
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+CMD ["npx", "NeteaseCloudMusicApi"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,21 @@ services:
     ports:
       - 25884:25884
     restart: always
+    environment:
+      # 所有变量都不是必填项
+      # 网易云服务端 IP, 可在宿主机通过 ping music.163.com 获得
+      - NETEASE_SERVER_IP=220.197.30.65
+      # UnblockNeteaseMusic 使用的音源, 支持列表见 https://github.com/UnblockNeteaseMusic/server?tab=readme-ov-file#%E9%9F%B3%E6%BA%90%E6%B8%85%E5%8D%95
+      - UNBLOCK_SOURCES=kugou kuwo bilibili
+      # 可添加 UnblockNeteaseMusic 支持的任何环境变量, 支持列表见 https://github.com/UnblockNeteaseMusic/server?tab=readme-ov-file#%E7%8E%AF%E5%A2%83%E5%8F%98%E9%87%8F
+      - ENABLE_FLAC=false
+      - ENABLE_HTTPDNS=false
+      - BLOCK_ADS=true
+      - DISABLE_UPGRADE_CHECK=false
+      - DEVELOPMENT=false
+      - FOLLOW_SOURCE_ORDER=true
+      - JSON_LOG=false
+      - NO_CACHE=false
+      - SELECT_MAX_BR=true
+      - LOG_LEVEL=info
+      - SEARCH_ALBUM=true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+# start unblock service in the background
+npx unblockneteasemusic -p 80:443 -s -f ${NETEASE_SERVER_IP:-220.197.30.65} -o ${UNBLOCK_SOURCES:-kugou kuwo bilibili} 2>&1 &
+
+# point the neteasemusic address to the unblock service
+if ! grep -q "music.163.com" /etc/hosts; then
+    echo "127.0.0.1 music.163.com" >> /etc/hosts
+fi
+if ! grep -q "interface.music.163.com" /etc/hosts; then
+    echo "127.0.0.1 interface.music.163.com" >> /etc/hosts
+fi
+if ! grep -q "interface3.music.163.com" /etc/hosts; then
+    echo "127.0.0.1 interface3.music.163.com" >> /etc/hosts
+fi
+if ! grep -q "interface.music.163.com.163jiasu.com" /etc/hosts; then
+    echo "127.0.0.1 interface.music.163.com.163jiasu.com" >> /etc/hosts
+fi
+if ! grep -q "interface3.music.163.com.163jiasu.com" /etc/hosts; then
+    echo "127.0.0.1 interface3.music.163.com.163jiasu.com" >> /etc/hosts
+fi
+
+# start the nginx daemon
+nginx
+
+# start the main process
+exec "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,6 +15,22 @@ server {
     rewrite ^(.*)$ /index.html last;
   }
 
+  location /api/netease/song/url/v1 {
+    proxy_buffers           16 64k;
+    proxy_buffer_size       128k;
+    proxy_busy_buffers_size 256k;
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $remote_addr;
+    proxy_set_header        X-Forwarded-Host $remote_addr;
+    proxy_set_header        X-NginX-Proxy true;
+    proxy_pass              http://localhost:3000/song/url/v1;
+    
+    sub_filter              '"url":"https://music.163.com' '"url":"/music/unblock';
+    sub_filter_types        application/json;
+    sub_filter_once         off;
+  }
+
   location /api/netease/ {
     proxy_buffers           16 64k;
     proxy_buffer_size       128k;
@@ -25,5 +41,11 @@ server {
     proxy_set_header        X-Forwarded-Host $remote_addr;
     proxy_set_header        X-NginX-Proxy true;
     proxy_pass              http://localhost:3000/;
+  }
+
+  location /music/unblock/ {
+    proxy_pass              https://music.163.com/;
+    proxy_buffering         off;
+    proxy_request_buffering off;
   }
 }


### PR DESCRIPTION
Docker 镜像内置 UnblockNeteaseMusic 服务，解锁部分无版权歌曲，可能会与原曲不匹配。

### 思路：

1. Docker 镜像内置 UnblockNeteaseMusic 服务，用于通过其它音源解锁网易云部分无版权歌曲；
2. 通过 hosts 将网易云服务地址指向 UnblockNeteaseMusic 服务；
3. Nginx 反向代理 UnblockNeteaseMusic 解锁过后的歌曲地址，避免在网页客户端信任 UnblockNeteaseMusic 证书，例如：`/music/unblock -> https://music.163.com/`，此处的 `https://music.163.com` 已经由 hosts 指向了本地 UnblockNeteaseMusic 服务；
4. Nginx 修改 `/api/netease/song/url/v1` 接口响应结果，将 UnblockNeteaseMusic 解锁过后的歌曲地址指向第三步反代的路径，例如：`https://music.163.com/package/xxxxx -> /music/unblock/package/xxxxx`；

### 实现：

1. Docker 镜像构建时内置 UnblockNeteaseMusic 服务，关键代码改动：

```dockerfile
# Dockerfile
FROM nginx:1.27-alpine-slim AS app

COPY --from=builder /app/out/renderer /usr/share/nginx/html

COPY --from=builder /app/nginx.conf /etc/nginx/conf.d/default.conf

COPY --from=builder /app/docker-entrypoint.sh /docker-entrypoint.sh

RUN apk add --no-cache npm python3 youtube-dl \
    && npm install -g @unblockneteasemusic/server NeteaseCloudMusicApi \
    && wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp \
    && chmod +x /usr/local/bin/yt-dlp \
    && chmod +x /docker-entrypoint.sh

ENV NODE_TLS_REJECT_UNAUTHORIZED=0

ENTRYPOINT ["/docker-entrypoint.sh"]

CMD ["npx", "NeteaseCloudMusicApi"]
```

2. 通过 hosts 将网易云服务地址指向本地 UnblockNeteaseMusic 服务，关键代码改动；

```shell
# docker-entrypoint.sh
#!/bin/sh

set -e

# start unblock service in the background
npx unblockneteasemusic -p 80:443 -s -f ${NETEASE_SERVER_IP:-220.197.30.65} -o ${UNBLOCK_SOURCES:-kugou kuwo bilibili} 2>&1 &

# point the neteasemusic address to the unblock service
if ! grep -q "music.163.com" /etc/hosts; then
    echo "127.0.0.1 music.163.com" >> /etc/hosts
fi
if ! grep -q "interface.music.163.com" /etc/hosts; then
    echo "127.0.0.1 interface.music.163.com" >> /etc/hosts
fi
if ! grep -q "interface3.music.163.com" /etc/hosts; then
    echo "127.0.0.1 interface3.music.163.com" >> /etc/hosts
fi
if ! grep -q "interface.music.163.com.163jiasu.com" /etc/hosts; then
    echo "127.0.0.1 interface.music.163.com.163jiasu.com" >> /etc/hosts
fi
if ! grep -q "interface3.music.163.com.163jiasu.com" /etc/hosts; then
    echo "127.0.0.1 interface3.music.163.com.163jiasu.com" >> /etc/hosts
fi

# start the nginx daemon
nginx

# start the main process
exec "$@"
```

3. Nginx 反向代理 UnblockNeteaseMusic 解锁过后的歌曲地址，此处因为媒体流文件较大禁用了缓存，关键代码改动；

```nginx
location /music/unblock/ {
  proxy_pass              https://music.163.com/;
  proxy_buffering         off;
  proxy_request_buffering off;
}
```

4. Nginx 修改 `/api/netease/song/url/v1` 接口响应结果，将 UnblockNeteaseMusic 解锁过后的歌曲地址指向反代路径，关键代码改动；

```nginx
location /api/netease/song/url/v1 {
  proxy_buffers           16 64k;
  proxy_buffer_size       128k;
  proxy_busy_buffers_size 256k;
  proxy_set_header        Host $host;
  proxy_set_header        X-Real-IP $remote_addr;
  proxy_set_header        X-Forwarded-For $remote_addr;
  proxy_set_header        X-Forwarded-Host $remote_addr;
  proxy_set_header        X-NginX-Proxy true;
  proxy_pass              http://localhost:3000/song/url/v1;
  
  sub_filter              '"url":"https://music.163.com' '"url":"/music/unblock';
  sub_filter_types        application/json;
  sub_filter_once         off;
}
```