### PR TITLE
feat(Setting): 更新音质选项并添加新选择

### DIFF
--- a/src/components/Setting/PlaySetting.vue
+++ b/src/components/Setting/PlaySetting.vue
@@ -252,29 +252,44 @@ const songLevelData = {
     value: "higher",
   },
   exhigh: {
-    label: "极高 HQ",
-    tip: "近 CD 品质的细节体验，最高 320kbps",
+    label: "极高 (HQ)",
+    tip: "近CD品质的细节体验，最高320kbps",
     value: "exhigh",
   },
   lossless: {
-    label: "无损 SQ",
-    tip: "高保真无损音质，最高 48kHz/16bit",
+    label: "无损 (SQ)",
+    tip: "高保真无损音质，最高48kHz/16bit",
     value: "lossless",
   },
   hires: {
-    label: "高清臻音 Spatial Audio",
-    tip: "环绕声体验，声音听感增强，96kHz/24bit",
+    label: "高解析度无损 (Hi-Res)",
+    tip: "更饱满清晰的高解析度音质，最高192kHz/24bit",
     value: "hires",
   },
+  jyeffect: {
+    label: "高清臻音 (Spatial Audio)",
+    tip: "声音听感增强，96kHz/24bit",
+    value: "jyeffect",
+  },
   jymaster: {
-    label: "超清母带 Master",
+    label: "超清母带 (Master)",
     tip: "还原音频细节，192kHz/24bit",
     value: "jymaster",
   },
   sky: {
-    label: "沉浸环绕声 Surround Audio",
-    tip: "沉浸式体验，最高 5.1 声道",
+    label: "沉浸环绕声 (Surround Audio)",
+    tip: "沉浸式空间环绕音感，最高5.1声道",
     value: "sky",
+  },
+  vivid: {
+    label: "臻音全景声 (Audio Vivid)",
+    tip: "极致沉浸三维空间音频，最高7.1.4声道",
+    value: "vivid",
+  },
+  dolby: {
+    label: "杜比全景声 (Dolby Atmos)",
+    tip: "杜比全景声音乐，沉浸式聆听体验",
+    value: "dolby",
   },
 };
 


### PR DESCRIPTION
- 参考手机端，更新音质说明文案
- 增加 jyeffect、vivid、dolby 音质


主要参考反编译的代码 
```
{
    "dolby": {
        "desc": "杜比全景声音乐，沉浸式聆听体验",
        "showAudioSize": 1,
        "title": "杜比全景声 (Dolby Atmos)"
    },
    "exhigh": {
        "desc": "近CD品质的细节体验，最高320kbps",
        "showAudioSize": 1,
        "title": "极高 (HQ)"
    },
    "hires": {
        "desc": "更饱满清晰的高解析度音质，最高192kHz/24bit",
        "showAudioSize": 1,
        "title": "高解析度无损 (Hi-Res)"
    },
    "jyeffect": {
        "desc": "声音听感增强，96kHz/24bit",
        "showAudioSize": 1,
        "title": "高清臻音 (Spatial Audio)"
    },
    "jymaster": {
        "desc": "还原音频细节，192kHz/24bit",
        "showAudioSize": 1,
        "title": "超清母带 (Master)"
    },
    "lossless": {
        "desc": "高保真无损音质，最高48kHz/16bit",
        "showAudioSize": 1,
        "title": "无损 (SQ)"
    },
    "sky": {
        "desc": "沉浸式空间环绕音感，最高5.1声道",
        "showAudioSize": 0,
        "title": "沉浸环绕声 (Surround Audio)"
    },
    "standard": {
        "desc": "128kbps",
        "showAudioSize": 1,
        "title": "标准"
    }
}
```
```
public enum MusicAudioQuality {
    DOLBY(2999000, "dolby", 7, g.f16828a),
    JY_MASTER(4999000, "jymaster", 9, g.f16840g),
    JY_EFFECT(3999000, "jyeffect", 8, g.f16838f),
    NETEASE_EFFECT(1999000, "hires", -2, g.f16844i),
    IMMERSE_EFFECT(4099000, "sky", 10, g.f16836e),
    VIVID_EFFECT(5999000, "vivid", 11, g.f16848k),
    HIRES(1999000, "hires", 6, g.f16834d),
    LOSSLESS(999000, "lossless", 5, g.f16842h),
    EXHIGH(320000, "exhigh", 4, g.f16832c),
    HIGHER(GameHouseClient.REC_BITRATE, "higher", 3, g.f16830b),
    STANDARD(128000, Constants.COLLATION_STANDARD, 2, g.f16846j);
```