### PR TITLE
fix: 修复 macos 和linux 本地歌曲路径问题

### DIFF
--- a/src/components/Modal/SongInfoEditor.vue
+++ b/src/components/Modal/SongInfoEditor.vue
@@ -262,7 +262,7 @@ const onlineMatch = debounce(
 const changeCover = async () => {
   const newPath = await window.electron.ipcRenderer.invoke("choose-image");
   if (!newPath) return;
-  coverData.value = newPath;
+  coverData.value = `file://${newPath}`;
 };
 
 // 实时修改列表
@@ -300,7 +300,9 @@ const saveSongInfo = debounce(async (song: SongType) => {
       cover:
         coverData.value.startsWith("blob:") || coverData.value === "/images/song.jpg?assest"
           ? null
-          : coverData.value,
+          : coverData.value.startsWith("file://")
+            ? coverData.value.replace(/^file:\/\//, "")
+            : coverData.value,
     };
     console.log(song.path, metadata);
     await window.electron.ipcRenderer.invoke("set-music-metadata", song.path, metadata);

--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -90,6 +90,7 @@ export const openSongInfoEditor = (song: SongType) => {
     preset: "card",
     transformOrigin: "center",
     autoFocus: false,
+    trapFocus: false,
     // contentStyle: { padding: 0 },
     style: { width: "600px" },
     title: "编辑歌曲信息",

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -549,7 +549,7 @@ class Player {
       statusStore.playLoading = true;
       // 本地歌曲
       if (path) {
-        await this.createPlayer(path, autoPlay, seek);
+        await this.createPlayer(`file://${path}`, autoPlay, seek);
         // 获取歌曲元信息
         await this.parseLocalMusicInfo(path);
       }


### PR DESCRIPTION
- 在 macos 和 linux 读取本地文件需要添加 file:// 前缀
- windows 也支持 file:// 前缀
- 在创建播放器时，为本地歌曲路径添加 file:// 前缀
- 在修改歌曲封面时，为本地路径添加 file:// 前缀
- 在保存元数据时，移除 file:// 前缀以保持兼容性
- 修复 编辑歌曲信息弹窗无法复制（路径和md5）