### PR TITLE
fix(getOnlineUrl): 修复网页端登录后获取url的CORS问题

### DIFF
--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -162,8 +162,9 @@ class Player {
       } else return null;
     }
     // 返回歌曲地址
-    // 客户端直接返回，网页端转 https
-    const url = isElectron ? songData.url : songData.url.replace(/^http:/, "https:");
+    // 客户端直接返回，网页端转 https, 并转换url以便解决音乐链接cors问题
+    const url = isElectron ? songData.url : songData.url.replace(/^http:/, "https:").replace(/m804\.music\.126\.net/g, 'm801.music.126.net').replace(/m704\.music\.126\.net/g, 'm701.music.126.net');
+    console.log(`🎧 ${id} music url:`, url);
     return url;
   }
   /**


### PR DESCRIPTION
## 为什么要修改这里？
简单来说，CORS（跨域资源共享）是浏览器的一种安全机制。它要求网站A想从网站B加载资源时，网站B的服务器必须明确表示“我允许网站A来拿我的资源”。如果服务器没有给出这个“许可”，浏览器就会拦截这个请求。

### 网易云音乐的音乐链接有个特点：

- 未登录时获取的链接（通常是 m801 或 m701 开头的域名）是配置好了这个“许可”的。

- 登录后获取的链接（通常是 m804 或 m704 开头的域名）反而没有配置这个“许可”。

这就导致了一个问题：当我们直接使用登录后的链接去请求音乐时，浏览器会因为安全规则（CORS）而阻止。

### 解决方案很简单：
既然未登录的链接有“许可”，而登录前后的链接只有域名不同，那我们只需要把登录后链接里的域名（m804/m704）替换成未登录的域名（m801/m701）就可以了。这样，我们就能绕过浏览器的CORS限制，正常播放音乐。