### PR TITLE
fix: adjust minimum window size 调整最小窗口大小

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -116,8 +116,8 @@ class MainProcess {
     const options: BrowserWindowConstructorOptions = {
       width: this.store?.get("window").width,
       height: this.store?.get("window").height,
-      minHeight: 800,
-      minWidth: 1280,
+      minHeight: 600,
+      minWidth: 800,
       // 菜单栏
       titleBarStyle: "customButtonsOnHover",
       // 立即显示窗口


### PR DESCRIPTION
原本的 1280×800 会造成很多问题，在屏幕宽度小于 1280px 的时候 (如 1080p 屏幕竖放) 在 Ubuntu GNOME 下甚至直接无法全屏只能保持窗口化。因此作此修改，调整最小的窗口大小应该也不会对其他功能造成任何影响。