### PR TITLE
feat: 记忆窗口最大化状态

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -123,13 +123,8 @@ class MainProcess {
       // 立即显示窗口
       show: false,
     };
-    const isMaximized = this.store?.get("window").maximized;
     // 初始化窗口
     this.mainWindow = this.createWindow(options);
-    // 加载完成后窗口最大化
-    this.mainWindow.on("ready-to-show", () => {
-      if (isMaximized) this.mainWindow?.maximize();
-    })
 
     // 渲染路径
     if (isDev && process.env["ELECTRON_RENDERER_URL"]) {
@@ -242,6 +237,8 @@ class MainProcess {
     this.mainWindow?.on("ready-to-show", () => {
       if (!this.mainWindow) return;
       this.thumbar = initThumbar(this.mainWindow);
+      const isMaximized = this.store?.get("window").maximized;
+      if (isMaximized) this.mainWindow.maximize();
     });
     this.mainWindow?.on("show", () => {
       // this.mainWindow?.webContents.send("lyricsScroll");
@@ -292,6 +289,7 @@ class MainProcess {
       bounds.maximized = this.mainWindow?.isMaximized();
       this.store?.set("window", bounds);
     }
+    console.log("bounds", bounds);
   }
   // 显示窗口
   showWindow() {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -301,7 +301,6 @@ class MainProcess {
       bounds.maximized = this.mainWindow?.isMaximized();
       this.store?.set("window", bounds);
     }
-    console.log("bounds", bounds);
   }
   // 显示窗口
   showWindow() {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2,7 +2,7 @@ import { app, shell, BrowserWindow, BrowserWindowConstructorOptions } from "elec
 import { electronApp } from "@electron-toolkit/utils";
 import { join } from "path";
 import { release, type } from "os";
-import { isDev, isMac, appName } from "./utils";
+import { isDev, isMac, appName, isLinux } from "./utils";
 import { unregisterShortcuts } from "./shortcut";
 import { initTray, MainTray } from "./tray";
 import { initThumbar, Thumbar } from "./thumbar";
@@ -261,6 +261,18 @@ class MainProcess {
     this.mainWindow?.on("unmaximize", () => {
       this.saveBounds();
     })
+
+    // Linux 无法使用 resized 和 moved
+    if (isLinux) {
+      this.mainWindow?.on("resize", () => {
+        // 若处于全屏则不保存
+        if (this.mainWindow?.isFullScreen()) return;
+        this.saveBounds();
+      })
+      this.mainWindow?.on("move", () => {
+        this.saveBounds();
+      });
+    }
 
     // 歌词窗口缩放
     this.lyricWindow?.on("resized", () => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -123,8 +123,13 @@ class MainProcess {
       // 立即显示窗口
       show: false,
     };
+    const isMaximized = this.store?.get("window").maximized;
     // 初始化窗口
     this.mainWindow = this.createWindow(options);
+    // 加载完成后窗口最大化
+    this.mainWindow.on("ready-to-show", () => {
+      if (isMaximized) this.mainWindow?.maximize();
+    })
 
     // 渲染路径
     if (isDev && process.env["ELECTRON_RENDERER_URL"]) {
@@ -244,7 +249,7 @@ class MainProcess {
     this.mainWindow?.on("focus", () => {
       this.saveBounds();
     });
-    // 移动或缩放
+    // 移动、缩放、最大化、取消最大化
     this.mainWindow?.on("resized", () => {
       // 若处于全屏则不保存
       if (this.mainWindow?.isFullScreen()) return;
@@ -253,6 +258,12 @@ class MainProcess {
     this.mainWindow?.on("moved", () => {
       this.saveBounds();
     });
+    this.mainWindow?.on("maximize", () => {
+      this.saveBounds();
+    });
+    this.mainWindow?.on("unmaximize", () => {
+      this.saveBounds();
+    })
 
     // 歌词窗口缩放
     this.lyricWindow?.on("resized", () => {
@@ -276,8 +287,11 @@ class MainProcess {
   // 更新窗口大小
   saveBounds() {
     if (this.mainWindow?.isFullScreen()) return;
-    const bounds = this.mainWindow?.getBounds();
-    if (bounds) this.store?.set("window", bounds);
+    const bounds: any = this.mainWindow?.getBounds();
+    if (bounds) {
+      bounds.maximized = this.mainWindow?.isMaximized();
+      this.store?.set("window", bounds);
+    }
   }
   // 显示窗口
   showWindow() {

--- a/electron/main/store.ts
+++ b/electron/main/store.ts
@@ -10,6 +10,7 @@ export interface StoreType {
     height: number;
     x?: number;
     y?: number;
+    maximized?: boolean;
   };
   lyric: {
     fontSize: number;


### PR DESCRIPTION
窗口貌似不会记忆最大化状态（看似最大化了，实际上没有，只是窗口大小和最大化一致）

顺便修了下 Linux 几乎不记忆窗口信息的 bug（Linux 无法使用 resized 和 moved，至少在我电脑上这两个事件不会触发）