### PR TITLE
fix: dev.mjs linux/mac 无法启动开发环境

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -41,10 +41,10 @@ if (isWindows) {
   console.log(`🐧 ${isMacOS ? "macOS" : "Linux"} 环境 - 正在设置 UTF-8 编码`);
   env.LC_ALL = "en_US.UTF-8";
   env.LANG = "en_US.UTF-8";
-  startElectronVite();
+  setTimeout(() => startElectronVite(), 0);
 }
 
- 
+
 const startElectronVite = () => {
   console.log("🔧 正在启动 Electron Vite 开发服务器...");
 


### PR DESCRIPTION
在 `isWindows` 分支中，`startElectronVite` 函数正常启动
在 `else` 分支中，`startElectronVite` 函数在定义之前就被调用了