### PR TITLE
fix: 恢复窗口最大化状态时过早显示窗口

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -237,8 +237,6 @@ class MainProcess {
     this.mainWindow?.on("ready-to-show", () => {
       if (!this.mainWindow) return;
       this.thumbar = initThumbar(this.mainWindow);
-      const isMaximized = this.store?.get("window").maximized;
-      if (isMaximized) this.mainWindow.maximize();
     });
     this.mainWindow?.on("show", () => {
       // this.mainWindow?.webContents.send("lyricsScroll");

--- a/electron/main/ipcMain.ts
+++ b/electron/main/ipcMain.ts
@@ -62,6 +62,8 @@ const initWinIpcMain = (
     if (loadingWin && !loadingWin.isDestroyed()) loadingWin.close();
     win?.show();
     win?.focus();
+    const isMaximized = store?.get("window")?.maximized;
+    if (isMaximized) win?.maximize();
   });
 
   // 最小化


### PR DESCRIPTION
在恢复窗口的最大化状态时，窗口还未加载完成就调用了 `maximize` 导致窗口过早显示