### PR TITLE
feat: 对本地歌词的修改

### DIFF
--- a/electron/main/ipcMain.ts
+++ b/electron/main/ipcMain.ts
@@ -25,6 +25,7 @@ import log from "../main/logger";
 import Store from "electron-store";
 import fg from "fast-glob";
 import openLoginWin from "./loginWin";
+import path from "node:path";
 
 // 注册 ipcMain
 const initIpcMain = (
@@ -304,6 +305,18 @@ const initWinIpcMain = (
       }
     },
   );
+
+
+  // 读取本地歌词
+  ipcMain.handle("read-local-lyric", async (_, lyricDir: string, id: number, ext: string): Promise<string> => {
+    const lyricPath = path.join(lyricDir, `${id}.${ext}`);
+    try {
+      await fs.access(lyricPath);
+      const lyric = await fs.readFile(lyricPath, "utf-8")
+      if (lyric) return lyric;
+    } catch {}
+    return "";
+  })
 
   // 删除文件
   ipcMain.handle("delete-file", async (_, path: string) => {

--- a/electron/main/ipcMain.ts
+++ b/electron/main/ipcMain.ts
@@ -243,27 +243,35 @@ const initWinIpcMain = (
   });
 
   // 获取音乐歌词
-  ipcMain.handle("get-music-lyric", async (_, path: string): Promise<string> => {
+  ipcMain.handle("get-music-lyric", async (_, path: string): Promise<{
+    lyric: string, format: "lrc" | "ttml"
+  }> => {
     try {
       const filePath = resolve(path).replace(/\\/g, "/");
       const { common } = await parseFile(filePath);
+
+      // 尝试获取同名的歌词文件
+      const filePathWithoutExt = filePath.replace(/\.[^.]+$/, "");
+      for (let ext of ["ttml", "lrc"] as const) {
+        const lyricPath = `${filePathWithoutExt}.${ext}`;
+        console.log("lyricPath", lyricPath);
+        try {
+          await fs.access(lyricPath);
+          const lyric = await fs.readFile(lyricPath, "utf-8")
+          if (lyric && lyric != "") return { lyric, format: ext };
+        } catch {}
+      }
+
+      // 尝试获取元数据
       const lyric = common?.lyrics?.[0]?.syncText;
       if (lyric && lyric.length > 0) {
-        return metaDataLyricsArrayToLrc(lyric);
+        return { lyric: metaDataLyricsArrayToLrc(lyric), format: "lrc" };
       } else if (common?.lyrics?.[0]?.text) {
-        return common?.lyrics?.[0]?.text;
+        return { lyric: common?.lyrics?.[0]?.text, format: "lrc" };
       }
-      // 如果歌词数据不存在，尝试读取同名的 lrc 文件
-      else {
-        const lrcFilePath = filePath.replace(/\.[^.]+$/, ".lrc");
-        try {
-          await fs.access(lrcFilePath);
-          const lrcData = await fs.readFile(lrcFilePath, "utf-8");
-          return lrcData || "";
-        } catch {
-          return "";
-        }
-      }
+
+      // 没有歌词
+      return { lyric: "", format: "lrc" };
     } catch (error) {
       log.error("❌ Error fetching music lyric:", error);
       throw error;

--- a/electron/main/ipcMain.ts
+++ b/electron/main/ipcMain.ts
@@ -316,7 +316,7 @@ const initWinIpcMain = (
       if (lyric) return lyric;
     } catch {}
     return "";
-  })
+  });
 
   // 删除文件
   ipcMain.handle("delete-file", async (_, path: string) => {

--- a/src/components/Setting/LocalSetting.vue
+++ b/src/components/Setting/LocalSetting.vue
@@ -22,7 +22,7 @@
             <n-text class="name">本地歌曲目录</n-text>
             <n-text class="tip" :depth="3">可在此增删本地歌曲目录，歌曲增删实时同步</n-text>
           </div>
-          <n-button strong secondary @click="changeLocalPath()">
+          <n-button strong secondary @click="changeLocalMusicPath()">
             <template #icon>
               <SvgIcon name="Folder" />
             </template>
@@ -38,7 +38,40 @@
             <div class="label">
               <n-text class="name">{{ item }}</n-text>
             </div>
-            <n-button strong secondary @click="changeLocalPath(index)">
+            <n-button strong secondary @click="changeLocalMusicPath(index)">
+              <template #icon>
+                <SvgIcon name="Delete" />
+              </template>
+            </n-button>
+          </n-card>
+        </n-collapse-transition>
+      </n-card>
+      <n-card class="set-item" id="local-list-choose" content-style="flex-direction: column">
+        <n-flex justify="space-between">
+          <div class="label">
+            <n-text class="name">本地歌词覆盖在线歌词</n-text>
+            <n-text class="tip" :depth="3"
+              >可在这些文件夹内覆盖在线歌曲的歌词，将歌词文件命名为 `歌曲ID.后缀名` 即可，支持 LRC
+              和 TTML 格式</n-text
+            >
+          </div>
+          <n-button strong secondary @click="changeLocalLyricPath()">
+            <template #icon>
+              <SvgIcon name="Folder" />
+            </template>
+            更改
+          </n-button>
+        </n-flex>
+        <n-collapse-transition :show="settingStore.localLyricPath.length > 0">
+          <n-card
+            v-for="(item, index) in settingStore.localLyricPath"
+            :key="index"
+            class="set-item"
+          >
+            <div class="label">
+              <n-text class="name">{{ item }}</n-text>
+            </div>
+            <n-button strong secondary @click="changeLocalLyricPath(index)">
               <template #icon>
                 <SvgIcon name="Delete" />
               </template>
@@ -125,7 +158,7 @@
 
 <script setup lang="ts">
 import { useSettingStore } from "@/stores";
-import { changeLocalPath } from "@/utils/helper";
+import { changeLocalLyricPath, changeLocalMusicPath, changeLocalPath } from "@/utils/helper";
 
 const settingStore = useSettingStore();
 

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -135,6 +135,8 @@ interface SettingState {
   preventSleep: boolean;
   /** 本地文件路径 */
   localFilesPath: string[];
+  /** 本地歌词路径 */
+  localLyricPath: string[];
   /** 本地文件分隔符 */
   localSeparators: string[];
   /** 显示本地封面 */
@@ -216,6 +218,7 @@ export const useSettingStore = defineStore("setting", {
     lrcMousePause: false,
     excludeKeywords: keywords,
     localFilesPath: [],
+    localLyricPath: [],
     showDefaultLocalPath: true,
     localSeparators: ["/", "&"],
     showLocalCover: true,

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -345,7 +345,7 @@ const changeLocalPath = (
     console.error(`${errorConsole}: `, error);
     window.$message.error(errorMessage);
   }
-}
+};
 
 /**
  * 更改本地音乐目录
@@ -366,7 +366,7 @@ export const changeLocalLyricPath = changeLocalPath(
   "localLyricPath", false,
   "Error changing local lyric path",
   "更改本地歌词文件夹出错，请重试",
-)
+);
 
 /**
  * 洗牌数组（Fisher-Yates）

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -183,7 +183,7 @@ export const parseLocalLyric = (lyric: string, format: "lrc" | "ttml") => {
       parseLocalLyricAM(lyric, musicStore)
       break;
   }
-}
+};
 const parseLocalLyricLrc = (lyric: string, musicStore: any) => {
   // 解析
   const lrc: LyricLine[] = parseLrc(lyric);

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -1,4 +1,4 @@
-import { LyricLine, parseLrc, parseYrc, TTMLLyric } from "@applemusic-like-lyrics/lyric";
+import { LyricLine, parseLrc, parseTTML, parseYrc, TTMLLyric } from "@applemusic-like-lyrics/lyric";
 import type { LyricType } from "@/types/main";
 import { useMusicStore, useSettingStore, useStatusStore } from "@/stores";
 import { msToS } from "./time";
@@ -169,12 +169,22 @@ export const alignAMLyrics = (
 };
 
 // 处理本地歌词
-export const parseLocalLyric = (lyric: string) => {
+export const parseLocalLyric = (lyric: string, format: "lrc" | "ttml") => {
   if (!lyric) {
     resetSongLyric();
     return;
   }
   const musicStore = useMusicStore();
+  switch (format) {
+    case "lrc":
+      parseLocalLyricLrc(lyric, musicStore)
+      break;
+    case "ttml":
+      parseLocalLyricAM(lyric, musicStore)
+      break;
+  }
+}
+const parseLocalLyricLrc = (lyric: string, musicStore: any) => {
   // 解析
   const lrc: LyricLine[] = parseLrc(lyric);
   const lrcData: LyricType[] = parseLrcData(lrc);
@@ -207,6 +217,19 @@ export const parseLocalLyric = (lyric: string) => {
     yrcData: [],
     yrcAMData: [],
   };
+};
+const parseLocalLyricAM = (lyric: string, musicStore: any) => {
+  const ttml = parseTTML(lyric);
+  const yrcAMData = parseTTMLToAMLL(ttml);
+  const yrcData = parseTTMLToYrc(ttml);
+  musicStore.songLyric = {
+    lrcData: yrcData,
+    lrcAMData: yrcAMData,
+    yrcAMData,
+    yrcData,
+  };
+  console.log(ttml);
+  console.log(yrcAMData);
 };
 
 // 处理 AM 歌词

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -228,8 +228,6 @@ const parseLocalLyricAM = (lyric: string, musicStore: any) => {
     yrcAMData,
     yrcData,
   };
-  console.log(ttml);
-  console.log(yrcAMData);
 };
 
 // 处理 AM 歌词

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -477,8 +477,8 @@ class Player {
       // 获取主色
       getCoverColor(musicStore.playSong.cover);
       // 获取歌词数据
-      const lrcData = await window.electron.ipcRenderer.invoke("get-music-lyric", path);
-      parseLocalLyric(lrcData);
+      const { lyric, format } = await window.electron.ipcRenderer.invoke("get-music-lyric", path);
+      parseLocalLyric(lyric, format);
       // 更新媒体会话
       this.updateMediaSession();
     } catch (error) {


### PR DESCRIPTION
- 本地音乐优先使用外部歌词而非音乐内封歌词
   因为个人认为内封的歌词不好取出，而单独文件的歌词可以更好地移除和修改，所以单独文件的歌词优先级高于内封歌词
- 支持本地 TTML 歌词，将同名 .ttml 文件放在此音乐相同位置即可
- 支持从本地特定位置读取 .lrc 和 .ttml 歌词覆盖线上歌词
   因为部分线上歌词质量低劣，可以自己修改以获得更好观感，也可以尝试 AMLL TTML DB 中尚未被合并的歌词

## 修改

### 本地音乐歌词的修改

Commit 信息里的 TTML 手快打错了，不要在意（

修改了 `ipcMain.ts` 中的 `get-music-lyric` 和 `lyric.ts` 中的 `parseLocalLyric` 使其支持 ttml 的同时提高从文件读取歌词的优先级，`player.ts` 中的调用也跟着改了

### 支持从本地读取歌词覆盖线上歌词

- 增加了 `localLyricPath` 设置项
   这个设置项和 `localFilesPath` 很像，因此为了减少代码重合，重构了 `helper.ts` 中的 `changeLocalPath` 使其可以应对更多情况
- 在 `ipcMain.ts` 中增加 `read-local-lyric` 以使用路径、歌曲ID、扩展名读取覆盖的歌词文件
- 在 `lyric.ts` 中获取线上歌词前先调用 `read-local-lyric` 获取本地的覆盖歌词