### PR TITLE
feat: 优化启用 TTML 选项的逻辑

### DIFF
--- a/src/components/Setting/LyricsSetting.vue
+++ b/src/components/Setting/LyricsSetting.vue
@@ -262,9 +262,9 @@
       </n-card>
       <n-card class="set-item">
         <div class="label">
-          <n-text class="name">启用 TTML 歌词</n-text>
+          <n-text class="name">启用在线 TTML 歌词</n-text>
           <n-text class="tip" :depth="3">
-            是否启用 TTML 歌词（如有），TTML 歌词支持逐字、翻译、音译等功能, 将会在下一首歌生效
+            是否从 AMLL TTML DB 获取歌词（如有），TTML 歌词支持逐字、翻译、音译等功能，将会在下一首歌生效
           </n-text>
         </div>
         <n-switch v-model:value="settingStore.enableTTMLLyric" class="set" :round="false" />

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -127,7 +127,7 @@ interface SettingState {
   useAMLyrics: boolean;
   /** 是否使用 AM 歌词弹簧效果 */
   useAMSpring: boolean;
-  /** 是否启用 TTML 歌词 */
+  /** 是否启用在线 TTML 歌词 */
   enableTTMLLyric: boolean;
   /** 菜单显示封面 */
   menuShowCover: boolean;

--- a/src/utils/player-utils/lyric.ts
+++ b/src/utils/player-utils/lyric.ts
@@ -22,7 +22,7 @@ export const getLyricData = async (id: number) => {
     const getLyric = getLyricFun(settingStore.localLyricPath, id);
     const [lyricRes, ttmlContent] = await Promise.all([
       getLyric("lrc", songLyric),
-      settingStore.enableTTMLLyric && getLyric("ttml", songLyricTTML),
+      settingStore.enableTTMLLyric ? getLyric("ttml", songLyricTTML) : getLyric("ttml"),
     ]);
     parsedLyricsData(lyricRes);
     if (ttmlContent) {
@@ -64,11 +64,11 @@ const getLyricFun =
   (paths: string[], id: number) =>
   async (
     ext: string,
-    getOnline: (id: number) => Promise<string | null>,
+    getOnline?: (id: number) => Promise<string | null>,
   ): Promise<string | null> => {
     for (const path of paths) {
       const lyric = await window.electron.ipcRenderer.invoke("read-local-lyric", path, id, ext);
       if (lyric) return lyric;
     }
-    return await getOnline(id);
+    return getOnline ? await getOnline(id) : null;
   };


### PR DESCRIPTION
原先的逻辑不太统一，一边受选项控制，一边不受选项控制

现在将所有的本地 TTML 加载都改为不受选项控制，只要本地文件存在则始终启用，且将设置项「启用 TTML 歌词」更名为「启用在线 TTML 歌词」