### PR TITLE
feat(lyric): 优化歌词排除

### DIFF
--- a/src/assets/data/exclude.ts
+++ b/src/assets/data/exclude.ts
@@ -75,4 +75,4 @@ export const keywords = [
 export const regexes = [
   /^[Oo][Pp]\s*[:：]/,
   /^[Ss][Pp]\s*[:：]/,
-];
+].map((regex) => regex.source);

--- a/src/assets/data/exclude.ts
+++ b/src/assets/data/exclude.ts
@@ -66,12 +66,13 @@ export const keywords = [
   "缩混",
   "音乐总监",
   "音乐制作",
-  "OP",
-  "SP",
-  "op",
-  "sp",
   "Talkbox",
   "Producers",
   "Producer",
   "Produced",
+];
+
+export const regexes = [
+  /^[Oo][Pp]\s*[:：]/,
+  /^[Ss][Pp]\s*[:：]/,
 ];

--- a/src/components/Modal/ExcludeKeywords.vue
+++ b/src/components/Modal/ExcludeKeywords.vue
@@ -1,14 +1,45 @@
 <template>
   <div class="exclude">
     <n-alert :show-icon="false">请勿添加过多，以免影响歌词的正常显示</n-alert>
-    <n-dynamic-tags v-model:value="settingStore.excludeKeywords" />
+
+    <n-tabs type="line" v-model:value="page" animated>
+      <n-tab-pane name="keywords" tab="关键词">
+        <n-dynamic-tags v-model:value="settingStore.excludeKeywords" />
+      </n-tab-pane>
+      <n-tab-pane name="regexes" tab="正则表达式">
+        <n-dynamic-tags v-model:value="regexesString" />
+      </n-tab-pane>
+
+      <template #suffix>
+        <n-button type="primary" strong secondary @click="reset">重置此页</n-button>
+      </template>
+    </n-tabs>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useSettingStore } from "@/stores";
+import { keywords, regexes } from "@/assets/data/exclude";
 
 const settingStore = useSettingStore();
+
+const page = ref("keywords");
+
+const reset = () => {
+  switch (page.value) {
+    case "keywords":
+      settingStore.excludeKeywords = keywords;
+      break;
+    case "regexes":
+      settingStore.excludeRegexes = regexes;
+      break;
+  }
+};
+
+const regexesString = computed({
+  get: () => settingStore.excludeRegexes.map((regex) => regex.source),
+  set: (values) => settingStore.excludeRegexes = values.map((value) => new RegExp(value)),
+});
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Modal/ExcludeLyrics.vue
+++ b/src/components/Modal/ExcludeLyrics.vue
@@ -7,7 +7,7 @@
         <n-dynamic-tags v-model:value="settingStore.excludeKeywords" />
       </n-tab-pane>
       <n-tab-pane name="regexes" tab="正则表达式">
-        <n-dynamic-tags v-model:value="regexesString" />
+        <n-dynamic-tags v-model:value="settingStore.excludeRegexes" />
       </n-tab-pane>
 
       <template #suffix>
@@ -35,14 +35,6 @@ const reset = () => {
       break;
   }
 };
-
-const regexesString = computed({
-  get: () => settingStore.excludeRegexes.map((regex) => regex.source),
-  set: (values) => settingStore.excludeRegexes = values.map((value) => new RegExp(value)),
-});
-
-console.log(settingStore.excludeRegexes);
-console.log(regexesString.value);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Modal/ExcludeLyrics.vue
+++ b/src/components/Modal/ExcludeLyrics.vue
@@ -40,6 +40,9 @@ const regexesString = computed({
   get: () => settingStore.excludeRegexes.map((regex) => regex.source),
   set: (values) => settingStore.excludeRegexes = values.map((value) => new RegExp(value)),
 });
+
+console.log(settingStore.excludeRegexes);
+console.log(regexesString.value);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Player/MainPlayer.vue
+++ b/src/components/Player/MainPlayer.vue
@@ -278,7 +278,7 @@ const sliderDragend = () => {
 
 // 是否展示歌词
 const isShowLyrics = computed(() => {
-  const isHasLrc = settingStore.showYrc ? musicStore.isHasYrc : musicStore.isHasLrc;
+  const isHasLrc = musicStore.isHasLrc;
   return (
     isHasLrc &&
     settingStore.barLyricShow &&

--- a/src/components/Player/MainPlayer.vue
+++ b/src/components/Player/MainPlayer.vue
@@ -278,7 +278,7 @@ const sliderDragend = () => {
 
 // 是否展示歌词
 const isShowLyrics = computed(() => {
-  const isHasLrc = musicStore.isHasLrc;
+  const isHasLrc = settingStore.showYrc ? musicStore.isHasYrc : musicStore.isHasLrc;
   return (
     isHasLrc &&
     settingStore.barLyricShow &&

--- a/src/components/Setting/LyricsSetting.vue
+++ b/src/components/Setting/LyricsSetting.vue
@@ -236,16 +236,16 @@
         <div class="label">
           <n-text class="name">启用歌词排除</n-text>
           <n-text class="tip" :depth="3">
-            开启后可配置排除关键词，包含关键词的歌词将不会显示
+            开启后可配置排除歌词，包含关键词或匹配正则表达式的歌词行将不会显示
           </n-text>
         </div>
-        <n-switch v-model:value="settingStore.enableExcludeKeywords" class="set" :round="false" />
+        <n-switch v-model:value="settingStore.enableExcludeLyrics" class="set" :round="false" />
       </n-card>
-      <n-collapse-transition :show="settingStore.enableExcludeKeywords">
+      <n-collapse-transition :show="settingStore.enableExcludeLyrics">
         <n-card class="set-item">
           <div class="label">
             <n-text class="name">歌词排除内容</n-text>
-            <n-text class="tip" :depth="3"> 歌词中包含的关键词将不会显示 </n-text>
+            <n-text class="tip" :depth="3"> 包含关键词或匹配正则表达式的歌词行将不会显示 </n-text>
           </div>
           <n-button type="primary" strong secondary @click="openLyricExclude">配置</n-button>
         </n-card>

--- a/src/components/Setting/LyricsSetting.vue
+++ b/src/components/Setting/LyricsSetting.vue
@@ -244,6 +244,16 @@
       <n-collapse-transition :show="settingStore.enableExcludeLyrics">
         <n-card class="set-item">
           <div class="label">
+            <n-text class="name">TTML 歌词排除</n-text>
+            <n-text class="tip" :depth="3">
+              是否要对 TTML 歌词进行歌词排除 <br/>
+              AMLL TTML DB 对此有硬性规定，不得包含作词、作曲等歌词无关内容，因此大多情况下无需开启
+            </n-text>
+          </div>
+          <n-switch v-model:value="settingStore.enableTTMLExclude" class="set" :round="false" />
+        </n-card>
+        <n-card class="set-item">
+          <div class="label">
             <n-text class="name">歌词排除内容</n-text>
             <n-text class="tip" :depth="3"> 包含关键词或匹配正则表达式的歌词行将不会显示 </n-text>
           </div>

--- a/src/components/Setting/LyricsSetting.vue
+++ b/src/components/Setting/LyricsSetting.vue
@@ -250,7 +250,16 @@
               AMLL TTML DB 对此有硬性规定，不得包含作词、作曲等歌词无关内容，因此大多情况下无需开启
             </n-text>
           </div>
-          <n-switch v-model:value="settingStore.enableTTMLExclude" class="set" :round="false" />
+          <n-switch v-model:value="settingStore.enableExcludeTTML" class="set" :round="false" />
+        </n-card>
+        <n-card class="set-item">
+          <div class="label">
+            <n-text class="name">本地歌词排除</n-text>
+            <n-text class="tip" :depth="3">
+              是否要对来自本地的歌词进行歌词排除，这包含本地覆盖的在线歌词和本地歌曲中的歌词
+            </n-text>
+          </div>
+          <n-switch v-model:value="settingStore.enableExcludeLocalLyrics" class="set" :round="false" />
         </n-card>
         <n-card class="set-item">
           <div class="label">

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -157,6 +157,8 @@ export interface SettingState {
   useKeepAlive: boolean;
   /** 是否启用排除歌词 */
   enableExcludeLyrics: boolean;
+  /** 「排除歌词」是否适用于 TTML */
+  enableTTMLExclude: boolean;
   /** 排除歌词关键字 */
   excludeKeywords: string[];
   /** 排除歌词正则表达式 */
@@ -221,6 +223,7 @@ export const useSettingStore = defineStore("setting", {
     lyricsScrollPosition: "start",
     lrcMousePause: false,
     enableExcludeLyrics: true,
+    enableTTMLExclude: false,
     excludeKeywords: keywords,
     excludeRegexes: regexes,
     localFilesPath: [],

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -158,7 +158,9 @@ export interface SettingState {
   /** 是否启用排除歌词 */
   enableExcludeLyrics: boolean;
   /** 「排除歌词」是否适用于 TTML */
-  enableTTMLExclude: boolean;
+  enableExcludeTTML: boolean;
+  /** 「排除歌词」是否适用于本地歌词 */
+  enableExcludeLocalLyrics: boolean;
   /** 排除歌词关键字 */
   excludeKeywords: string[];
   /** 排除歌词正则表达式 */
@@ -223,7 +225,8 @@ export const useSettingStore = defineStore("setting", {
     lyricsScrollPosition: "start",
     lrcMousePause: false,
     enableExcludeLyrics: true,
-    enableTTMLExclude: false,
+    enableExcludeTTML: false,
+    enableExcludeLocalLyrics: false,
     excludeKeywords: keywords,
     excludeRegexes: regexes,
     localFilesPath: [],

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
-import { keywords } from "@/assets/data/exclude";
+import { keywords, regexes } from "@/assets/data/exclude";
 
-interface SettingState {
+export interface SettingState {
   /** 明暗模式 */
   themeMode: "light" | "dark" | "auto";
   /** 主题类别 */
@@ -155,10 +155,12 @@ interface SettingState {
   dynamicCover: boolean;
   /** 是否使用 keep-alive */
   useKeepAlive: boolean;
-  /** 是否启用排除歌词关键字 */
-  enableExcludeKeywords: boolean;
+  /** 是否启用排除歌词 */
+  enableExcludeLyrics: boolean;
   /** 排除歌词关键字 */
   excludeKeywords: string[];
+  /** 排除歌词正则表达式 */
+  excludeRegexes: RegExp[],
   /** 显示默认本地路径 */
   showDefaultLocalPath: boolean;
 }
@@ -218,8 +220,9 @@ export const useSettingStore = defineStore("setting", {
     lyricsBlur: false,
     lyricsScrollPosition: "start",
     lrcMousePause: false,
-    enableExcludeKeywords: true,
+    enableExcludeLyrics: true,
     excludeKeywords: keywords,
+    excludeRegexes: regexes,
     localFilesPath: [],
     localLyricPath: [],
     showDefaultLocalPath: true,

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -160,7 +160,7 @@ export interface SettingState {
   /** 排除歌词关键字 */
   excludeKeywords: string[];
   /** 排除歌词正则表达式 */
-  excludeRegexes: RegExp[],
+  excludeRegexes: string[],
   /** 显示默认本地路径 */
   showDefaultLocalPath: boolean;
 }

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -315,6 +315,7 @@ export const parseTTMLToAMLL = (ttmlContent: TTMLLyric): LyricLine[] => {
   if (!ttmlContent) return [];
 
   try {
+    const settingsStore = useSettingStore()
     const validLines = ttmlContent.lines
       .filter((line) => line && typeof line === "object" && Array.isArray(line.words))
       .map((line) => {
@@ -334,7 +335,7 @@ export const parseTTMLToAMLL = (ttmlContent: TTMLLyric): LyricLine[] => {
           .join("")
           .trim();
         // 排除包含关键词的内容
-        if (!content || isLyricExcluded(content)) {
+        if (!content || (settingsStore.enableTTMLExclude && isLyricExcluded(content))) {
           return null;
         }
 

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -101,7 +101,7 @@ export const parseLrcData = (lrcData: LyricLine[]): LyricType[] => {
       const time = msToS(words[0].startTime);
       const content = words[0].word.trim();
       // 排除内容
-      if (!content || getExcludeKeywords().some((keyword) => content.includes(keyword))) {
+      if (!content || isLyricExcluded(content)) {
         return null;
       }
       return {
@@ -137,7 +137,7 @@ export const parseYrcData = (yrcData: LyricLine[]): LyricType[] => {
         .map((word) => word.content + (word.endsWithSpace ? " " : ""))
         .join("");
       // 排除内容
-      if (!contentStr || getExcludeKeywords().some((keyword) => contentStr.includes(keyword))) {
+      if (!contentStr || isLyricExcluded(contentStr)) {
         return null;
       }
       return {
@@ -274,7 +274,7 @@ const parseAMData = (lrcData: LyricLine[], tranData?: LyricLine[], romaData?: Ly
         .join("")
         .trim();
       // 排除包含关键词的内容
-      if (!content || getExcludeKeywords().some((keyword) => content.includes(keyword))) {
+      if (!content || isLyricExcluded(content)) {
         return null;
       }
       return {
@@ -328,7 +328,7 @@ export const parseTTMLToAMLL = (ttmlContent: TTMLLyric): LyricLine[] => {
           .join("")
           .trim();
         // 排除包含关键词的内容
-        if (!content || getExcludeKeywords().some((keyword) => content.includes(keyword))) {
+        if (!content || isLyricExcluded(content)) {
           return null;
         }
 
@@ -383,7 +383,7 @@ export const parseTTMLToYrc = (ttmlContent: TTMLLyric): LyricType[] => {
           .map((word) => word.content + (word.endsWithSpace ? " " : ""))
           .join("");
         // 排除内容
-        if (!contentStr || getExcludeKeywords().some((keyword) => contentStr.includes(keyword))) {
+        if (!contentStr || isLyricExcluded(contentStr)) {
           return null;
         }
         return {

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -18,13 +18,9 @@ const getExcludeRegexes = (settings: SettingState = useSettingStore()): RegExp[]
 
 // 是否排除歌词行
 const isLyricExcluded = (line: string) => {
-  const statusStore = useStatusStore();
   const settingStore = useSettingStore();
 
   if (!settingStore.enableExcludeLyrics) {
-    return false;
-  }
-  if (statusStore.usingTTMLLyric && !settingStore.enableExcludeTTML) {
     return false;
   }
   const excludeKeywords = getExcludeKeywords(settingStore);

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -21,6 +21,9 @@ const isLyricExcluded = (line: string) => {
   const statusStore = useStatusStore();
   const settingStore = useSettingStore();
 
+  if (!settingStore.enableExcludeLyrics) {
+    return false;
+  }
   if (statusStore.usingTTMLLyric && !settingStore.enableTTMLExclude) {
     return false;
   }
@@ -370,6 +373,7 @@ export const parseTTMLToYrc = (ttmlContent: TTMLLyric): LyricType[] => {
   if (!ttmlContent) return [];
 
   try {
+    const settingStore = useSettingStore()
     // 数据处理
     const yrcList = ttmlContent.lines
       .map((line) => {
@@ -390,7 +394,7 @@ export const parseTTMLToYrc = (ttmlContent: TTMLLyric): LyricType[] => {
           .map((word) => word.content + (word.endsWithSpace ? " " : ""))
           .join("");
         // 排除内容
-        if (!contentStr || isLyricExcluded(contentStr)) {
+        if (!contentStr || (settingStore.enableTTMLExclude && isLyricExcluded(contentStr))) {
           return null;
         }
         return {

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -18,8 +18,14 @@ const getExcludeRegexes = (settings: SettingState = useSettingStore()): RegExp[]
 
 // 是否排除歌词行
 const isLyricExcluded = (line: string) => {
-  const excludeKeywords = getExcludeKeywords();
-  const excludeRegexes = getExcludeRegexes();
+  const statusStore = useStatusStore();
+  const settingStore = useSettingStore();
+
+  if (statusStore.usingTTMLLyric && !settingStore.enableTTMLExclude) {
+    return false;
+  }
+  const excludeKeywords = getExcludeKeywords(settingStore);
+  const excludeRegexes = getExcludeRegexes(settingStore);
   return (
     excludeKeywords.some((keyword) => line.includes(keyword)) ||
     excludeRegexes.some((regex) => regex.test(line))

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -1,14 +1,29 @@
 import { LyricLine, parseLrc, parseTTML, parseYrc, TTMLLyric } from "@applemusic-like-lyrics/lyric";
 import type { LyricType } from "@/types/main";
 import { useMusicStore, useSettingStore, useStatusStore } from "@/stores";
+import { SettingState } from "@/stores/setting";
 import { msToS } from "./time";
 
-// 歌词排除内容
-const getExcludeKeywords = () => {
-  const settingStore = useSettingStore();
-  // 如果未启用排除功能，返回空数组
-  if (!settingStore.enableExcludeKeywords) return [];
-  return settingStore.excludeKeywords;
+// 歌词排除关键词
+const getExcludeKeywords = (settings: SettingState = useSettingStore()): string[] => {
+  if (!settings.enableExcludeLyrics) return [];
+  return settings.excludeKeywords;
+};
+
+// 歌词排除正则
+const getExcludeRegexes = (settings: SettingState = useSettingStore()): RegExp[] => {
+  if (!settings.enableExcludeLyrics) return [];
+  return settings.excludeRegexes;
+};
+
+// 是否排除歌词行
+const isLyricExcluded = (line: string) => {
+  const excludeKeywords = getExcludeKeywords();
+  const excludeRegexes = getExcludeRegexes();
+  return (
+    excludeKeywords.some((keyword) => line.includes(keyword)) ||
+    excludeRegexes.some((regex) => regex.test(line))
+  );
 };
 
 // 恢复默认

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -13,7 +13,7 @@ const getExcludeKeywords = (settings: SettingState = useSettingStore()): string[
 // 歌词排除正则
 const getExcludeRegexes = (settings: SettingState = useSettingStore()): RegExp[] => {
   if (!settings.enableExcludeLyrics) return [];
-  return settings.excludeRegexes;
+  return settings.excludeRegexes.map((regex) => new RegExp(regex));
 };
 
 // 是否排除歌词行

--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -16,7 +16,7 @@ import UpdatePlaylist from "@/components/Modal/UpdatePlaylist.vue";
 import DownloadSong from "@/components/Modal/DownloadSong.vue";
 import MainSetting from "@/components/Setting/MainSetting.vue";
 import UpdateApp from "@/components/Modal/UpdateApp.vue";
-import ExcludeKeywords from "@/components/Modal/ExcludeKeywords.vue";
+import ExcludeLyrics from "@/components/Modal/ExcludeLyrics.vue";
 import ChangeRate from "@/components/Modal/ChangeRate.vue";
 import AutoClose from "@/components/Modal/AutoClose.vue";
 import Equalizer from "@/components/Modal/Equalizer.vue";
@@ -248,7 +248,7 @@ export const openLyricExclude = () => {
     style: { width: "600px" },
     title: "歌词排除内容",
     content: () => {
-      return h(ExcludeKeywords);
+      return h(ExcludeLyrics);
     },
   });
 };

--- a/src/utils/player-utils/lyric.ts
+++ b/src/utils/player-utils/lyric.ts
@@ -30,7 +30,7 @@ export const getLyricData = async (id: number) => {
       getLyric("lrc", songLyric),
       settingStore.enableTTMLLyric ? getLyric("ttml", songLyricTTML) : getLyric("ttml"),
     ]);
-    parsedLyricsData(lyricRes, lyricLocal && settingStore.enableExcludeLocalLyrics);
+    parsedLyricsData(lyricRes, lyricLocal && !settingStore.enableExcludeLocalLyrics);
     if (ttmlContent) {
       const parsedResult = parseTTML(ttmlContent);
       if (!parsedResult?.lines?.length) {
@@ -65,6 +65,8 @@ export const getLyricData = async (id: number) => {
     } else {
       statusStore.usingTTMLLyric = false;
     }
+
+    console.log("Lyrics: ", musicStore.songLyric);
   } catch (error) {
     console.error("❌ Error loading lyrics:", error);
     statusStore.usingTTMLLyric = false;

--- a/src/utils/player-utils/lyric.ts
+++ b/src/utils/player-utils/lyric.ts
@@ -23,19 +23,25 @@ export const getLyricData = async (id: number) => {
   try {
     // 检测本地歌词覆盖
     const getLyric = getLyricFun(settingStore.localLyricPath, id);
-    const [lyricRes, ttmlContent] = await Promise.all([
+    const [
+      { lyric: lyricRes, isLocal: lyricLocal },
+      { lyric: ttmlContent, isLocal: ttmlLocal },
+    ] = await Promise.all([
       getLyric("lrc", songLyric),
       settingStore.enableTTMLLyric ? getLyric("ttml", songLyricTTML) : getLyric("ttml"),
     ]);
-    parsedLyricsData(lyricRes);
+    parsedLyricsData(lyricRes, lyricLocal && settingStore.enableExcludeLocalLyrics);
     if (ttmlContent) {
       const parsedResult = parseTTML(ttmlContent);
       if (!parsedResult?.lines?.length) {
         statusStore.usingTTMLLyric = false;
         return;
       }
-      const ttmlLyric = parseTTMLToAMLL(parsedResult);
-      const ttmlYrcLyric = parseTTMLToYrc(parsedResult);
+      const skipExcludeLocal = ttmlLocal && !settingStore.enableExcludeLocalLyrics;
+      const skipExcludeTTML = !settingStore.enableExcludeTTML;
+      const skipExclude = skipExcludeLocal || skipExcludeTTML;
+      const ttmlLyric = parseTTMLToAMLL(parsedResult, skipExclude);
+      const ttmlYrcLyric = parseTTMLToYrc(parsedResult, skipExclude);
       console.log("TTML lyrics:", ttmlLyric, ttmlYrcLyric);
       // 合并数据
       const updates: Partial<{ yrcAMData: LyricLine[]; yrcData: LyricType[] }> = {};
@@ -77,10 +83,10 @@ const getLyricFun =
   async (
     ext: string,
     getOnline?: (id: number) => Promise<string | null>,
-  ): Promise<string | null> => {
+  ): Promise<{ lyric: string | null; isLocal: boolean }> => {
     for (const path of paths) {
       const lyric = await window.electron.ipcRenderer.invoke("read-local-lyric", path, id, ext);
-      if (lyric) return lyric;
+      if (lyric) return { lyric, isLocal: true };
     }
-    return getOnline ? await getOnline(id) : null;
+    return { lyric: getOnline ? await getOnline(id) : null, isLocal: false };
   };


### PR DESCRIPTION
此 PR 已经编辑完成

主要变动：
- 增加 `excludeRegexes` 设置项，同时增加 `getExcludeRegexes` 函数
- 增加 `isLyricExcluded` 函数，并将所有排除歌词的逻辑替换为此函数
- `ExcludeKeywords` 改名为 `ExcludeLyrics`
- 在 `ExcludeLyrics` 中编辑 `excludeRegexes` 设置项
- 增加 `enableExcludeTTML` 设置项
- 增加 `enableExcludeLocalLyrics` 设置项
- 为所有调用了 `isLyricExcluded` 的函数增加 `skipExclude` 参数，调用这些函数的时候必须先判断 `enableExcludeTTML` 和 `enableExcludeLocalLyrics` 并以此传入 `skipExclude` 参数