### PR TITLE
fix(lyric): 增加对歌词显示进程被系统调用关闭时的处理

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, BrowserWindowConstructorOptions } from "electron";
+import { app, shell, BrowserWindow, BrowserWindowConstructorOptions, ipcMain } from "electron";
 import { electronApp } from "@electron-toolkit/utils";
 import { join } from "path";
 import { release, type } from "os";
@@ -280,6 +280,11 @@ class MainProcess {
         this.store?.set("lyric", { ...this.store?.get("lyric"), width, height });
       }
     });
+
+    this.lyricWindow?.on("close", (e) => {
+      e.preventDefault();
+      ipcMain.emit("closeDesktopLyric");
+    })
 
     // 窗口关闭
     this.mainWindow?.on("close", (event) => {


### PR DESCRIPTION
**问题描述:**

当通过系统调用来关闭歌词显示窗口时，程序将无法正确处理此情况 (虽然窗口本身隐藏了关闭窗口的入口，但如 linux 的 i3wm 桌面环境可以通过快捷键来关闭窗口而非像程序那样隐藏窗口)。

这样会导致以下报错:
<img width="880" height="345" alt="Sat Oct 25 19:30:36 CST 2025" src="https://github.com/user-attachments/assets/f6e13c03-9a1b-467a-818b-c60e27dde3a4" />

**解决方案:**

因此为了对齐歌词显示窗口的关闭逻辑，增加了对窗口关闭事件的处理。