### PR TITLE
fix: dev.mjs linux/macOS 设置 UTF-8

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -39,8 +39,18 @@ if (isWindows) {
 } else {
   // macOS 和 Linux 环境
   console.log(`🐧 ${isMacOS ? "macOS" : "Linux"} 环境 - 正在设置 UTF-8 编码`);
-  env.LC_ALL = "en_US.UTF-8";
-  env.LANG = "en_US.UTF-8";
+  const langVar = env.LC_ALL || env.LANG;
+  if (langVar.endsWith("UTF-8")) {
+    console.log("✅ 当前环境已设置 UTF-8 编码");
+  } else {
+    if (langVar.startsWith("zh_CN")) {
+      env.LC_ALL = "zh_CN.UTF-8";
+      env.LANG = "zh_CN.UTF-8";
+    } else {
+      env.LC_ALL = "en_US.UTF-8";
+      env.LANG = "en_US.UTF-8";
+    }
+  }
   setTimeout(() => startElectronVite(), 0);
 }
 


### PR DESCRIPTION
为什么要这样做呢？
因为我的系统根本没开英语选项，所以开发环境会导致如下报错（虽然不影响启动就是了

```
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
```