### PR TITLE
fix: 极端特殊情况下不显示歌词

### DIFF
--- a/src/components/Player/FullPlayer.vue
+++ b/src/components/Player/FullPlayer.vue
@@ -30,8 +30,8 @@
         :class="[
           'player-content',
           {
-            pure: statusStore.pureLyricMode && musicStore.isHasLrc,
-            'no-lrc': settingStore.showYrc ? !musicStore.isHasYrc : !musicStore.isHasLrc,
+            pure: statusStore.pureLyricMode && isHasLyric(),
+            'no-lrc': !isHasLyric(),
           },
         ]"
         @mousemove="playerMove"
@@ -39,7 +39,7 @@
         <Transition name="zoom">
           <div
             v-if="
-              !(statusStore.pureLyricMode && musicStore.isHasLrc) ||
+              !(statusStore.pureLyricMode && isHasLyric()) ||
               musicStore.playSong.type === 'radio'
             "
             :key="musicStore.playSong.id"
@@ -55,7 +55,7 @@
         <div class="content-right">
           <!-- 数据 -->
           <PlayerData
-            v-if="statusStore.pureLyricMode && musicStore.isHasLrc"
+            v-if="statusStore.pureLyricMode && isHasLyric()"
             :center="statusStore.pureLyricMode"
             :theme="statusStore.mainColor"
           />
@@ -86,6 +86,7 @@ import { useStatusStore, useMusicStore, useSettingStore } from "@/stores";
 import { isElectron } from "@/utils/env";
 import { throttle } from "lodash-es";
 import player from "@/utils/player";
+import { isHasLyric } from "@/utils/lyric";
 
 const musicStore = useMusicStore();
 const statusStore = useStatusStore();
@@ -102,7 +103,7 @@ const playerContentKey = computed(() => `${statusStore.pureLyricMode}`);
 // 数据是否居中
 const playerDataCenter = computed<boolean>(
   () =>
-    !musicStore.isHasLrc ||
+    !isHasLyric() ||
     statusStore.pureLyricMode ||
     settingStore.playerType === "record" ||
     musicStore.playSong.type === "radio",

--- a/src/components/Player/FullPlayer.vue
+++ b/src/components/Player/FullPlayer.vue
@@ -31,7 +31,7 @@
           'player-content',
           {
             pure: statusStore.pureLyricMode && musicStore.isHasLrc,
-            'no-lrc': !musicStore.isHasLrc,
+            'no-lrc': settingStore.showYrc ? !musicStore.isHasYrc : !musicStore.isHasLrc,
           },
         ]"
         @mousemove="playerMove"

--- a/src/components/Player/PlayerMenu.vue
+++ b/src/components/Player/PlayerMenu.vue
@@ -4,7 +4,7 @@
       <div v-show="statusStore.playerMetaShow" class="menu-content">
         <n-flex class="left">
           <div
-            v-if="musicStore.isHasLrc && musicStore.playSong.type !== 'radio'"
+            v-if="isHasLyric() && musicStore.playSong.type !== 'radio'"
             :class="['menu-icon', { open: statusStore.pureLyricMode }]"
             @click="statusStore.pureLyricMode = !statusStore.pureLyricMode"
           >
@@ -27,6 +27,7 @@
 
 <script setup lang="ts">
 import { useStatusStore, useMusicStore } from "@/stores";
+import { isHasLyric } from "@/utils/lyric";
 
 const musicStore = useMusicStore();
 const statusStore = useStatusStore();

--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -51,6 +51,17 @@ export const resetSongLyric = () => {
 };
 
 /**
+ * 当前是否有歌词
+ */
+export const isHasLyric = () => {
+  const musicStore = useMusicStore();
+  const settingStore = useSettingStore();
+  const useYrc = settingStore.showYrc && musicStore.songLyric.yrcData?.length;
+  return useYrc ? musicStore.isHasYrc : musicStore.isHasLrc;
+};
+
+
+/**
  * 解析歌词数据
  * @param lyricData 歌词数据
  * @param skipExclude 是否跳过排除


### PR DESCRIPTION
修复当有 YRC 歌词但无 LRC 歌词的情况时，程序错误地认为没有歌词从而不显示的 BUG

这次的情况是这次网易云没有歌词但 AMLL TTML DB 有歌词，但 TTML 格式的歌词并没有被转换为 LRC 格式

这个问题其实我之前改过一次，但后来认为没有这种极端情况，就改回来了
事实是真的有这种情况，可以触发此 BUG 的是原神的四周年 EP，下面给出此歌曲的一个版本：

[经过 Passing Memories（伴奏 男调中文伴唱）](https://music.163.com/#/song?id=2631336275)

发现此 BUG 的：@ITManCHINA