### PR TITLE
fix(ttml): 行结束时间过早

### DIFF
--- a/src/utils/lyric.ts
+++ b/src/utils/lyric.ts
@@ -423,8 +423,8 @@ export const parseTTMLToAMLL = (
           return null;
         }
 
-        const startTime = words[0].startTime;
-        const endTime = words[words.length - 1].endTime;
+        const startTime = line.startTime || words[0].startTime;
+        const endTime = line.endTime || words[words.length - 1].endTime;
 
         return {
           words,


### PR DESCRIPTION
TTML 有时会为了触发一些效果（比如和下一行连起来）而故意延后行的结束时间（同时词的结束时间不变）

`parseTTMLToAMLL` 直接忽略了行的开始结束时间而采用词的开始结束时间，会导致和其他播放器的显示不一致