### PR TITLE
feat(LocalLyric): 使本地覆盖在线歌词的文件更好管理

### DIFF
--- a/electron/main/ipc/ipc-file.ts
+++ b/electron/main/ipc/ipc-file.ts
@@ -200,11 +200,15 @@ const initFileIpc = (): void => {
   ipcMain.handle(
     "read-local-lyric",
     async (_, lyricDir: string, id: number, ext: string): Promise<string> => {
-      const lyricPath = join(lyricDir, `${id}.${ext}`);
+      const pattern = `**/{,*.}${id}.${ext}`;
       try {
-        await access(lyricPath);
-        const lyric = await readFile(lyricPath, "utf-8");
-        if (lyric) return lyric;
+        const files = await FastGlob(pattern, { cwd: lyricDir });
+        if (files.length > 0) {
+          const firstMatch = join(lyricDir, files[0]);
+          await access(firstMatch);
+          const lyric = await readFile(firstMatch, "utf-8");
+          if (lyric) return lyric;
+        }
       } catch {
         /* empty */
       }

--- a/src/components/Setting/LocalSetting.vue
+++ b/src/components/Setting/LocalSetting.vue
@@ -50,10 +50,12 @@
         <n-flex justify="space-between">
           <div class="label">
             <n-text class="name">本地歌词覆盖在线歌词</n-text>
-            <n-text class="tip" :depth="3"
-              >可在这些文件夹内覆盖在线歌曲的歌词，将歌词文件命名为 `歌曲ID.后缀名` 即可，支持 LRC
-              和 TTML 格式</n-text
-            >
+            <n-text class="tip" :depth="3">
+              可在这些文件夹及其子文件夹内覆盖在线歌曲的歌词 <br />
+              将歌词文件命名为 `歌曲ID.后缀名` 或者 `任意前缀.歌曲ID.后缀名` 即可 <br />
+              支持 .lrc 和 .ttml 格式 <br />
+              （提示：可以在前缀加上歌名等信息，也可以利用子文件夹分类管理）
+            </n-text>
           </div>
           <n-button strong secondary @click="changeLocalLyricPath()">
             <template #icon>

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -367,7 +367,7 @@ export const changeLocalMusicPath = changeLocalPath(
  */
 export const changeLocalLyricPath = changeLocalPath(
   "localLyricPath",
-  false,
+  true,
   "Error changing local lyric path",
   "更改本地歌词文件夹出错，请重试",
   false,


### PR DESCRIPTION
使「本地歌词覆盖在线歌词」功能中的用户存放的文件更好管理

## 特性
 - 也支持将歌词文件命名为 `任意前缀.歌曲ID.后缀名` 的格式
 - 支持将歌词文件放在子文件夹

## 代码改动
 - 将 `ipc-file.ts` 中的 `read-local-lyric` 里写死的路径改成了 FastGlob 查找，因此支持了上述的两项功能
 - 更改 `LocalSettings.vue` 中的信息
 - 更改 `helper.ts` 中的 `changeLocalLyricPath` 方法，使其也会检测子目录