### PR TITLE
fix(lyric): 关闭在线 TTML 歌词后不获取本地 TTML 歌词了

### DIFF
--- a/src/utils/player-utils/lyric.ts
+++ b/src/utils/player-utils/lyric.ts
@@ -35,7 +35,7 @@ export const getLyricData = async (id: number) => {
 
     // 并发请求：如果 TTML 先到并且有效，则直接采用 TTML，不再等待或覆盖为 LRC
     const lrcPromise = getLyric("lrc", songLyric);
-    // 这里的 getLyric 不传第二次参数（在线获取函数）表明不进行在线获取，仅获取本地
+    // 这里的第二个 getLyric 方法不传入第二个参数（在线获取函数）表明不进行在线获取，仅获取本地
     const ttmlPromise = settingStore.enableTTMLLyric ? getLyric("ttml", songLyricTTML) : getLyric("ttml");
 
     let settled = false; // 是否已采用某一种歌词并结束加载状态

--- a/src/utils/player-utils/lyric.ts
+++ b/src/utils/player-utils/lyric.ts
@@ -35,6 +35,7 @@ export const getLyricData = async (id: number) => {
 
     // 并发请求：如果 TTML 先到并且有效，则直接采用 TTML，不再等待或覆盖为 LRC
     const lrcPromise = getLyric("lrc", songLyric);
+    // 这里的 getLyric 不传第二次参数（在线获取函数）表明不进行在线获取，仅获取本地
     const ttmlPromise = settingStore.enableTTMLLyric ? getLyric("ttml", songLyricTTML) : getLyric("ttml");
 
     let settled = false; // 是否已采用某一种歌词并结束加载状态

--- a/src/utils/player-utils/lyric.ts
+++ b/src/utils/player-utils/lyric.ts
@@ -35,7 +35,7 @@ export const getLyricData = async (id: number) => {
 
     // 并发请求：如果 TTML 先到并且有效，则直接采用 TTML，不再等待或覆盖为 LRC
     const lrcPromise = getLyric("lrc", songLyric);
-    const ttmlPromise = settingStore.enableTTMLLyric ? getLyric("ttml", songLyricTTML) : null;
+    const ttmlPromise = settingStore.enableTTMLLyric ? getLyric("ttml", songLyricTTML) : getLyric("ttml");
 
     let settled = false; // 是否已采用某一种歌词并结束加载状态
     let ttmlAdopted = false; // 是否已采用 TTML


### PR DESCRIPTION
是刻意这么写了吗？~~还是用 AI 重构的（~~

如果是刻意这么写的，设置和注释也要改一下

`enableTTMLLyric` 这名字我之前就想改掉的，但这可能会影响到很多地方，怕又改漏了出什么 BUG 就没改（

至于这是怎么发现的，就要看某个 issue 了，我在测试 bug 的时候发现的（