### PR TITLE
fix(player): 修复极端状态下播放异常

### DIFF
--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -912,6 +912,10 @@ class Player {
       console.warn("⚠️ Player not ready for seek");
       return;
     }
+    if (time < 0 || time > this.player.duration()) {
+      console.warn("⚠️ Invalid seek time", time);
+      time = Math.max(0, Math.min(time, this.player.duration()));
+    }
     this.player.seek(time);
     statusStore.currentTime = time;
   }


### PR DESCRIPTION
由于 `jumpSeek` 现在会减去 `offset`，可能会导致当 `offset` 超出预期时引发一些奇怪的行为

## 修改

在 `player.ts` 中的 `setSeek` 方法里，判断了 `time` 参数是否合法（在 0 到歌曲时长之间），若不合法则输出日志并修正