### PR TITLE
perf: 优化桌面歌词拖动时容易卡顿

### DIFF
--- a/src/views/DesktopLyric/index.vue
+++ b/src/views/DesktopLyric/index.vue
@@ -453,10 +453,28 @@ const startDrag = async (event: MouseEvent) => {
 };
 
 /**
+ * 触发函数节流
+ * @param fn 需要触发的函数
+ * @param wait 等待时间
+ */
+const throttle = (fn: Function, wait: number = 12)=> {
+  let canRun = true;
+
+  return function (this: any, ...args: any[]) {
+    if (!canRun) return;
+    canRun = false
+    setTimeout(()=>{
+      fn.apply(this,args);
+      canRun = true
+    },wait)
+  };
+};
+
+/**
  * 桌面歌词拖动移动
  * @param event 鼠标事件
  */
-const onDocMouseMove = async (event: MouseEvent) => {
+const onDocMouseMove = throttle(async (event: MouseEvent) => {
   if (!dragState.isDragging || lyricConfig.isLock) return;
   const screenX = event?.screenX ?? 0;
   const screenY = event?.screenY ?? 0;
@@ -477,7 +495,7 @@ const onDocMouseMove = async (event: MouseEvent) => {
     dragState.winWidth,
     dragState.winHeight,
   );
-};
+});
 
 /**
  * 桌面歌词拖动结束


### PR DESCRIPTION
## 问题
过快拖动或在 wallpaper 动态桌面下拖动桌面歌词都会造成非常严重的延迟、不跟手
具体情况如图
![截屏_2025-11-19_01-33-51](https://github.com/user-attachments/assets/9be38e88-7c1a-4c17-8ae8-f2e39a33613a)

## 修改
主要对鼠标移动事件做了节流，防止过多的触发