### PR TITLE
fix(playlist): 歌单描述有换行时并没有正确换行

### DIFF
--- a/src/views/List/playlist.vue
+++ b/src/views/List/playlist.vue
@@ -56,10 +56,11 @@
               :tooltip="{
                 trigger: 'click',
                 placement: 'bottom',
-                width: 'trigger',
               }"
             >
-              {{ playlistDetailData.description }}
+              <span style="white-space: pre;">
+                  {{ playlistDetailData.description }}
+              </span>
             </n-ellipsis>
             <!-- 信息 -->
             <n-flex class="meta">


### PR DESCRIPTION
为 `{{ playlistDetailData.description }}` 嵌套一层 `span` 并添加 `style="white-space: pre;"`

删除 `n-ellipsis` 中 `tooltip` 里对 `width` 的限制（以确保文字不超出 Tooltip）