### PR TITLE
fix(playlist): 歌单描述单行过长时超出屏幕

### DIFF
--- a/src/views/List/playlist.vue
+++ b/src/views/List/playlist.vue
@@ -58,9 +58,9 @@
                 placement: 'bottom',
               }"
             >
-              <span style="white-space: pre;">
-                  {{ playlistDetailData.description }}
-              </span>
+              <div style="white-space: pre-line; max-width: 90vw;" >
+                {{ playlistDetailData.description }}
+              </div>
             </n-ellipsis>
             <!-- 信息 -->
             <n-flex class="meta">


### PR DESCRIPTION
将嵌套的 `span` 改为 `div`
将 `white-space` 的值从 `pre` 改为 `pre-line`
添加 `max-width: 90vw;`