### PR TITLE
fix(build-linux): 规范 Desktop 文件

### DIFF
--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -152,7 +152,7 @@ const config: Configuration = {
     // 维护者信息
     maintainer: "imsyy.top",
     // 应用程序类别
-    category: "Audio;Music",
+    category: "Audio;Music;AudioVideo;",
   },
   // AppImage 特定配置
   appImage: {


### PR DESCRIPTION
根据 [FreeDesktop 规范](https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry)，具有 `Audio` (音频) 类别的桌面项必须也包含 `AudioVideo` (影音)