### PR TITLE
🐞fix: 修复错误的类型

### DIFF
--- a/src/components/Modal/CopyLyrics.vue
+++ b/src/components/Modal/CopyLyrics.vue
@@ -56,9 +56,8 @@ const rawLyrics = computed(() => {
 
 const displayLyrics = computed(() => {
   return rawLyrics.value.map((line, index) => {
-    // 兼容 lrcData (content) 和 yrcData (words)
     const text =
-      line.words?.map((w) => w.word).join("") || (line as any).content || (line as any).text || "";
+      line.words?.map((w) => w.word).join("") || "";
     const translation = line.translatedLyric || "";
     const romaji = line.romanLyric || line.words?.map((w) => w.romanWord).join("") || "";
     return {


### PR DESCRIPTION
#610 根据 AI 的幻觉引入了实际上并不存在的 `line.content` 和 `line.text` 的引用，建议移除以提高清晰度