### PR TITLE
:bug: fix: update dialog hyperlinks opening in Electron window

### DIFF
--- a/src/components/Modal/UpdateApp.vue
+++ b/src/components/Modal/UpdateApp.vue
@@ -10,7 +10,12 @@
       </n-tag>
     </n-flex>
     <n-scrollbar style="max-height: 500px">
-      <div v-if="data?.releaseNotes" class="markdown-body" v-html="data.releaseNotes" />
+      <div
+        v-if="data?.releaseNotes"
+        class="markdown-body"
+        v-html="data.releaseNotes"
+        @click="handleMarkdownClick"
+      />
       <div v-else class="markdown-body">暂无更新日志</div>
     </n-scrollbar>
     <n-flex class="menu" justify="end">
@@ -34,6 +39,19 @@ const emit = defineEmits<{ close: [] }>();
 // 下载更新数据
 const downloadStatus = ref<boolean>(false);
 const downloadProgress = ref<number>(0);
+
+// 处理markdown中的链接点击
+const handleMarkdownClick = (event: MouseEvent) => {
+  const target = event.target as HTMLElement;
+  // 检查是否点击的是链接
+  if (target.tagName?.toUpperCase() === "A") {
+    event.preventDefault();
+    const href = target.getAttribute("href");
+    if (href) {
+      window.open(href, "_blank");
+    }
+  }
+};
 
 // 开始更新
 const startDownload = async () => {

--- a/src/components/Modal/UpdateApp.vue
+++ b/src/components/Modal/UpdateApp.vue
@@ -43,13 +43,11 @@ const downloadProgress = ref<number>(0);
 // 处理markdown中的链接点击
 const handleMarkdownClick = (event: MouseEvent) => {
   const target = event.target as HTMLElement;
-  // 检查是否点击的是链接
-  if (target.tagName?.toUpperCase() === "A") {
+  // 从事件目标向上遍历，查找最近的 <a> 标签
+  const anchor = target.closest('a');
+  if (anchor?.href) {
     event.preventDefault();
-    const href = target.getAttribute("href");
-    if (href) {
-      window.open(href, "_blank");
-    }
+    window.open(anchor.href, '_blank');
   }
 };
 


### PR DESCRIPTION
修复了点击更新弹窗中的 Github 超链接会在 Electron 窗口内直接跳转，导致用户被困在更新页面的问题。

这个 PR 在 UpdateApp.vue 的 Markdown 容器中增加了点击处理逻辑来拦截链接，使用 window.open(href, '_blank') 从而触发主窗口现有的 setWindowOpenHandler 配置，调用系统浏览器来打开这些 URL。