### PR TITLE
fix：修复歌手信息跳转更新失败和歌手头像丢失问题

### DIFF
--- a/src/components/Modal/JumpArtist.vue
+++ b/src/components/Modal/JumpArtist.vue
@@ -87,26 +87,26 @@ const getArtistData = async () => {
     }
   } else if (Array.isArray(props.artist)) {
     // 检查是否有 cover 字段，如果没有则获取歌手详情
-    const hasCover = props.artist.some((ar) => ar.cover);
-    if (hasCover) {
-      artistData.value = props.artist;
-    } else {
-      // 获取每个歌手的详情以获取头像
-      const artistPromises = props.artist.map(async (ar) => {
-        try {
-          const result = await artistDetail(ar.id);
-          const artist = result.data?.artist;
-          return {
-            id: ar.id,
-            name: ar.name,
-            cover: artist?.cover || artist?.img1v1Url || artist?.picUrl,
-          };
-        } catch {
-          return { id: ar.id, name: ar.name, cover: undefined };
-        }
-      });
-      artistData.value = await Promise.all(artistPromises);
-    }
+    const artistPromises = props.artist.map(async (ar) => {
+      // 如果已有封面，则直接返回
+      if (ar.cover) {
+        return ar;
+      }
+      // 否则，获取歌手详情
+      try {
+        const result = await artistDetail(ar.id);
+        const artist = result.data?.artist;
+        return {
+          id: ar.id,
+          name: ar.name,
+          cover: artist?.cover || artist?.img1v1Url || artist?.picUrl,
+        };
+      } catch (error) {
+        console.error(`获取歌手 ${ar.name} (${ar.id}) 的详情失败:`, error);
+        return { id: ar.id, name: ar.name, cover: undefined };
+      }
+    });
+    artistData.value = await Promise.all(artistPromises);
   }
 };
 

--- a/src/views/Artist/layout.vue
+++ b/src/views/Artist/layout.vue
@@ -251,7 +251,9 @@ const listScroll = (e: Event) => {
 
 onBeforeRouteUpdate((to) => {
   listScrolling.value = false;
-  if (to.matched[0].name !== "artist") return;
+  // 检查是否仍在 artist 路由下
+  const isArtistRoute = to.matched.some((m) => m.name === "artist");
+  if (!isArtistRoute) return;
   artistType.value = to.name as string;
   const id = Number(to.query.id as string);
   if (id && id !== artistId.value) getArtistDetail(id);


### PR DESCRIPTION
1. 现在点击多个歌手名字时，歌手的头像和介绍都可以正常更新在页面了.
2. 跳转到歌手弹窗可以正常显示头像了。
<img width="889" height="366" alt="image" src="https://github.com/user-attachments/assets/1679587c-e6c6-467f-b8c9-7ce0bd0cd88e" />
