### PR TITLE
fix(cache): 修复缓存大小上限默认值处理

### DIFF
--- a/electron/main/services/MusicCacheService.ts
+++ b/electron/main/services/MusicCacheService.ts
@@ -75,7 +75,7 @@ export class MusicCacheService {
    */
   public async cacheMusic(id: number | string, url: string, quality: string): Promise<string> {
     const store = useStore();
-    const limitSizeGB = store.get("cacheLimit") || 10;
+    const limitSizeGB = store.get("cacheLimit") ?? 10;
     const limitSizeBytes = limitSizeGB * 1024 * 1024 * 1024;
 
     // 如果设置为 0，则不限制


### PR DESCRIPTION
`0` 是 falsy 值，使用 `||` 会导致预期为「不限制」的 `0` 被设置为默认值 `10`