### PR TITLE
feat(lastfm): 优化体验

### DIFF
--- a/src/components/Setting/ThirdSetting.vue
+++ b/src/components/Setting/ThirdSetting.vue
@@ -16,8 +16,13 @@
             <n-text class="name">API Key</n-text>
             <n-text class="tip" :depth="3">
               在
-              <n-a href="https://www.last.fm/api/account/create" target="_blank">Last.fm API</n-a>
-              创建应用获取
+              <n-a href="https://www.last.fm/zh/api/account/create" target="_blank">Last.fm 创建应用</n-a>
+              获取，只有「程序名称」是必要的
+            </n-text>
+            <n-text class="tip" :depth="3">
+              如果已经创建过，则可以在
+              <n-a href="https://www.last.fm/zh/api/accounts" target="_blank">Last.fm API 应用程序</n-a>
+              处查看
             </n-text>
           </div>
           <n-input


### PR DESCRIPTION
- 优化设置项的描述
- 将一些网址指向中文页面
- 请求失败时显示错误提示

（这错误提示怎么感觉有点问题的说：不知道 401 和 403 的部分情况要不要直接断开连接；报错会不会太频繁，但我感觉日常不太容易报错，或者说要考虑没网的情况什么的；或者说 Last.fm 这种不重要的就不报错了？感觉也不太好...）