### PR TITLE
style(setting): 优化本地目录样式

### DIFF
--- a/src/components/Setting/LocalSetting.vue
+++ b/src/components/Setting/LocalSetting.vue
@@ -26,7 +26,7 @@
             <template #icon>
               <SvgIcon name="Folder" />
             </template>
-            更改
+            添加
           </n-button>
         </n-flex>
         <n-collapse-transition :show="settingStore.localFilesPath.length > 0">
@@ -34,6 +34,7 @@
             v-for="(item, index) in settingStore.localFilesPath"
             :key="index"
             class="set-item"
+            content-style="padding: 4px 16px"
           >
             <div class="label">
               <n-text class="name">{{ item }}</n-text>
@@ -61,7 +62,7 @@
             <template #icon>
               <SvgIcon name="Folder" />
             </template>
-            更改
+            添加
           </n-button>
         </n-flex>
         <n-collapse-transition :show="settingStore.localLyricPath.length > 0">
@@ -69,6 +70,7 @@
             v-for="(item, index) in settingStore.localLyricPath"
             :key="index"
             class="set-item"
+            content-style="padding: 4px 16px"
           >
             <div class="label">
               <n-text class="name">{{ item }}</n-text>

--- a/src/views/Local/layout.vue
+++ b/src/views/Local/layout.vue
@@ -123,7 +123,7 @@
             <SvgIcon :size="20" name="Folder" />
           </template>
           <template #suffix>
-            <n-button quaternary @click="changeLocalMusicPath(index)">
+            <n-button :focusable="false" quaternary @click="changeLocalMusicPath(index)">
               <template #icon>
                 <SvgIcon :size="20" name="Delete" />
               </template>


### PR DESCRIPTION
- 优化设置页「本地与缓存」中的本地歌曲和歌词目录的样式
- 修复「本地歌曲」页面中「目录管理」被打开时意外选中第一个目录的删除按钮的问题