### PR TITLE
🐞 fix: 无边框窗口模式在重启程序之后自动打开

### DIFF
--- a/electron/main/windows/main-window.ts
+++ b/electron/main/windows/main-window.ts
@@ -24,7 +24,8 @@ class MainWindow {
     const bounds = this.win?.getBounds();
     if (bounds) {
       const maximized = this.win?.isMaximized();
-      store.set("window", { ...bounds, maximized });
+      const windowState = store.get("window");
+      store.set("window", { ...windowState, ...bounds, maximized });
     }
   }
   /**


### PR DESCRIPTION
窗口的 saveBounds 函数中没有保存 `useBorderless` 的值，而其默认的 store value 是 true，这导致了每次 saveBounds 的时候这个值在 store 中被删除，然后下次重启程序无边框模式就又自动开启了。