### PR TITLE
fix(lyric): 修复 TTML 多语言翻译

### DIFF
--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -542,15 +542,16 @@ class LyricManager {
       );
 
       // 按照指定顺序对翻译进行排序
+      // 按照指定顺序对翻译进行排序
       translationElements.sort((a, b) => {
-        const aLang = a.getAttribute("xml:lang") || a.getAttribute("lang") || "";
-        const bLang = b.getAttribute("xml:lang") || b.getAttribute("lang") || "";
+        const aLang = (a.getAttribute("xml:lang") || a.getAttribute("lang") || "").toLowerCase();
+        const bLang = (b.getAttribute("xml:lang") || b.getAttribute("lang") || "").toLowerCase();
 
         const aIndex = translationOrder.findIndex((lang) =>
-          aLang.toLowerCase().includes(lang.toLowerCase()),
+          aLang.startsWith(lang.toLowerCase()),
         );
         const bIndex = translationOrder.findIndex((lang) =>
-          bLang.toLowerCase().includes(lang.toLowerCase()),
+          bLang.startsWith(lang.toLowerCase()),
         );
 
         // 如果找不到指定语言，则放在最后

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -405,7 +405,8 @@ class LyricManager {
       }
       if (isStale()) return;
       if (!ttmlContent || typeof ttmlContent !== "string") return;
-      const parsed = parseTTML(ttmlContent);
+      const sorted = this.sortTTMLTranslations(ttmlContent);
+      const parsed = parseTTML(sorted);
       const lines = parsed?.lines || [];
       if (!lines.length) return;
       result.yrcData = lines;
@@ -488,7 +489,8 @@ class LyricManager {
       if (!lyric) return { lrcData: [], yrcData: [] };
       // TTML 直接返回
       if (format === "ttml") {
-        const ttml = parseTTML(lyric);
+        const sorted = this.sortTTMLTranslations(lyric);
+        const ttml = parseTTML(sorted);
         const lines = ttml?.lines || [];
         statusStore.usingTTMLLyric = true;
         return { lrcData: [], yrcData: lines };
@@ -512,6 +514,58 @@ class LyricManager {
     } catch {
       return { lrcData: [], yrcData: [] };
     }
+  }
+
+  /**
+   * 处理 TTML 内容并排序翻译
+   * @param ttmlContent 原始 TTML 内容
+   * @param translationOrder 翻译排序顺序
+   * @returns 排序后的 TTML 内容
+   */
+  // 此函数应该在 AMLL 的 TTML 解析器支持多语言翻译后删除
+  private sortTTMLTranslations(
+    ttmlContent: string,
+    translationOrder: string[] = ["zh-CN", "zh-Hans", "zh-TW", "zh-Hant"],
+  ): string {
+    // 使用 DOMParser 解析 XML 内容
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(ttmlContent, "text/xml");
+
+    // 查找所有歌词行元素
+    const lyricsElements = xmlDoc.querySelectorAll("tt > body > div > p");
+
+    lyricsElements.forEach((element: Element) => {
+      // 获取当前歌词行的所有翻译元素
+      const translationElements = Array.from(element.children).filter(
+        (child) =>
+          child.hasAttribute("ttm:role") && child.getAttribute("ttm:role") === "x-translation",
+      );
+
+      // 按照指定顺序对翻译进行排序
+      translationElements.sort((a, b) => {
+        const aLang = a.getAttribute("xml:lang") || a.getAttribute("lang") || "";
+        const bLang = b.getAttribute("xml:lang") || b.getAttribute("lang") || "";
+
+        const aIndex = translationOrder.findIndex((lang) =>
+          aLang.toLowerCase().includes(lang.toLowerCase()),
+        );
+        const bIndex = translationOrder.findIndex((lang) =>
+          bLang.toLowerCase().includes(lang.toLowerCase()),
+        );
+
+        // 如果找不到指定语言，则放在最后
+        return (aIndex === -1 ? Infinity : aIndex) - (bIndex === -1 ? Infinity : bIndex);
+      });
+
+      // 重新排列翻译元素
+      translationElements.forEach((translationElement) => {
+        element.appendChild(translationElement); // 移动到末尾以实现排序
+      });
+    });
+
+    // 序列化回字符串
+    const serializer = new XMLSerializer();
+    return serializer.serializeToString(xmlDoc);
   }
 
   /**


### PR DESCRIPTION
增加 `sortTTMLTranslations` 函数来排序翻译（此函数包含 AI 生成部分），可能确实有些问题，但也是作为临时解决方案，应该在 AMLL 的 TTML 解析器支持多语言翻译后删除

fix #718