### PR TITLE
使用「清理」替换「排序」逻辑，优先使用中文翻译

### DIFF
--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -579,16 +579,9 @@ class LyricManager {
       * @param lang 正则中第一个捕获组匹配到的语言代码 (例如 "ja-JP")
       */
       const replacer = (match: string, lang: string) => (lang === major_lang ? match : "");
-
-      if (ttml_text.indexOf("iTunesMetadata") !== -1) {
-        const translationRegex = /<translation[^>]+xml:lang="([^"]+)"[^>]*>[\s\S]*?<\/translation>/g;
-
-        return ttml_text.replace(translationRegex, replacer);
-      } else {
-        const spanRegex = /<span[^>]+xml:lang="([^"]+)"[^>]*>[\s\S]*?<\/span>/g;
-
-        return ttml_text.replace(spanRegex, replacer);
-      }
+      const translationRegex = /<translation[^>]+xml:lang="([^"]+)"[^>]*>[\s\S]*?<\/translation>/g;
+      const spanRegex = /<span[^>]+xml:lang="([^" ]+)"[^>]*>[\s\S]*?<\/span>/g;
+      return ttml_text.replace(translationRegex, replacer).replace(spanRegex, replacer);
     }
 
     const context_lang = lang_counter(ttmlContent);

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -416,7 +416,7 @@ class LyricManager {
       }
       if (isStale()) return;
       if (!ttmlContent || typeof ttmlContent !== "string") return;
-      const sorted = this.sortTTMLTranslations(ttmlContent);
+      const sorted = this.cleanTTMLTranslations(ttmlContent);
       const parsed = parseTTML(sorted);
       const lines = parsed?.lines || [];
       if (!lines.length) return;
@@ -500,7 +500,7 @@ class LyricManager {
       if (!lyric) return { lrcData: [], yrcData: [] };
       // TTML 直接返回
       if (format === "ttml") {
-        const sorted = this.sortTTMLTranslations(lyric);
+        const sorted = this.cleanTTMLTranslations(lyric);
         const ttml = parseTTML(sorted);
         const lines = ttml?.lines || [];
         statusStore.usingTTMLLyric = true;
@@ -534,52 +534,68 @@ class LyricManager {
   }
 
   /**
-   * 处理 TTML 内容并排序翻译
-   * @param ttmlContent 原始 TTML 内容
-   * @param translationOrder 翻译排序顺序
-   * @returns 排序后的 TTML 内容
-   */
-  // 此函数应该在 AMLL 的 TTML 解析器支持多语言翻译后删除
-  private sortTTMLTranslations(
-    ttmlContent: string,
-    translationOrder: string[] = ["zh-CN", "zh-Hans", "zh-TW", "zh-Hant"],
+  * 清洗 TTML 中不需要的翻译
+  * @param ttmlContent 原始 TTML 内容
+  * @returns 清洗后的 TTML 内容
+  */
+  // 当支持 i18n 之后，需要对其中的部分函数进行修改，使其优选逻辑能够根据用户界面语言变化
+  private cleanTTMLTranslations( // 一般没有多种音译，故不对音译部分进行清洗，如果需要请另写处理函数
+    ttmlContent: string
   ): string {
-    // 使用 DOMParser 解析 XML 内容
-    const parser = new DOMParser();
-    const xmlDoc = parser.parseFromString(ttmlContent, "text/xml");
+    const lang_counter = (ttml_text: string) => {
+      // 使用正则匹配所有 xml:lang="xx-XX" 格式的字符串
+      const langRegex = /(?<=<(span|translation)[^<>]+)xml:lang="([^"]+)"/g;
+      const matches = ttml_text.matchAll(langRegex);
 
-    // 查找所有歌词行元素
-    const lyricsElements = xmlDoc.querySelectorAll("tt > body > div > p");
+      // 提取匹配结果并去重
+      const langSet = new Set<string>();
+      for (const match of matches) {
+        if (match[2]) langSet.add(match[2]);
+      }
 
-    lyricsElements.forEach((element: Element) => {
-      // 获取当前歌词行的所有翻译元素
-      const translationElements = Array.from(element.children).filter(
-        (child) =>
-          child.hasAttribute("ttm:role") && child.getAttribute("ttm:role") === "x-translation",
-      );
+      return Array.from(langSet);
+    }
 
-      // 按照指定顺序对翻译进行排序
-      // 按照指定顺序对翻译进行排序
-      translationElements.sort((a, b) => {
-        const aLang = (a.getAttribute("xml:lang") || a.getAttribute("lang") || "").toLowerCase();
-        const bLang = (b.getAttribute("xml:lang") || b.getAttribute("lang") || "").toLowerCase();
+    const lang_filter = (langs: string[]) : (string | null) => {
+      if (langs.length <= 1) return null;
 
-        const aIndex = translationOrder.findIndex((lang) => aLang.startsWith(lang.toLowerCase()));
-        const bIndex = translationOrder.findIndex((lang) => bLang.startsWith(lang.toLowerCase()));
+      if (langs.includes('zh-Hans')) return 'zh-Hans';
+      if (langs.includes('zh-CN')) return 'zh-CN';
+      if (langs.includes('zh-Hant')) return 'zh-Hant';
 
-        // 如果找不到指定语言，则放在最后
-        return (aIndex === -1 ? Infinity : aIndex) - (bIndex === -1 ? Infinity : bIndex);
-      });
+      const major = langs.find(key => key.startsWith('zh'));
+      if (major) return major;
 
-      // 重新排列翻译元素
-      translationElements.forEach((translationElement) => {
-        element.appendChild(translationElement); // 移动到末尾以实现排序
-      });
-    });
+      return langs[0];
+    }
 
-    // 序列化回字符串
-    const serializer = new XMLSerializer();
-    return serializer.serializeToString(xmlDoc);
+    const ttml_cleaner = (ttml_text: string, major_lang: string | null): string => {
+      // 如果没有指定主语言，直接返回原文本（或者根据需求返回空）
+      if (major_lang === null) return ttml_text;
+
+      /**
+      * 替换逻辑回调函数
+      * @param match 完整匹配到的标签字符串 (例如 <code><span ...>...<\/span></code>)
+      * @param lang 正则中第一个捕获组匹配到的语言代码 (例如 "ja-JP")
+      */
+      const replacer = (match: string, lang: string) => (lang === major_lang ? match : "");
+
+      if (ttml_text.indexOf("iTunesMetadata") !== -1) {
+        const translationRegex = /<translation[^>]+xml:lang="([^"]+)"[^>]*>[\s\S]*?<\/translation>/g;
+
+        return ttml_text.replace(translationRegex, replacer);
+      } else {
+        const spanRegex = /<span[^>]+xml:lang="([^"]+)"[^>]*>[\s\S]*?<\/span>/g;
+
+        return ttml_text.replace(spanRegex, replacer);
+      }
+    }
+
+    const context_lang = lang_counter(ttmlContent);
+    const major = lang_filter(context_lang);
+    const cleaned_ttml = ttml_cleaner(ttmlContent, major);
+    
+    return cleaned_ttml;
   }
 
   /**


### PR DESCRIPTION
## 改动
- 删除 `sortTTMLTranslations` 方法
- 使用 `cleanTTMLTranslations` 方法进行替代

## 效果
- 提升处理速度：经测试，目前 ttml-db 中最大的多语言翻译文件处理时间只有 3ms
- 提高可扩展性：如果后续需要扩展「多语言翻译」相关功能，直接修改 `cleanTTMLTranslations` 方法及其中的 `lang_filter` 函数即可

## 未来
如果后续扩展了 i18n 相关功能，需要根据用户界面更换翻译时，同样需要修改 `cleanTTMLTranslations` 方法及其中的 `lang_filter` 函数，重点为 `lang_filter` 中的优选算法，需要使用短横线分隔语言代码向下选择，例如：文件中有 `en-GB` `en-CA` `en`，界面语言为 `en` 或 `en-US` 的用户应该匹配到 `en`，而文件中没有 `en` 时匹配到 `en-GB` 或 `en-CA`，下面是一个实例函数（应该能直接用）

````typescript
/**
 * 根据 major_lang 在 context_lang 中查找最匹配的语言。
 * * 逻辑：
 * 1. 精确匹配 context_lang 是否包含 major_lang。
 * 2. 前缀匹配 context_lang 中是否有以 major_lang 开头的项。
 * 3. 都没有，则去掉 major_lang 最后一个 "-" 及其内容，重复上述步骤。
 * 4. 如果循环结束仍无匹配，返回 context_lang 的第一个项。
 */
function findBestMatchLanguage(context_lang: string[], major_lang: string): string {
  // 防御性编程：如果列表为空，返回空字符串或根据需求抛出错误
  if (!context_lang || context_lang.length === 0) {
    return "";
  }

  let currentLang = major_lang;

  // 循环直到无法再拆分（即不包含 '-'）
  while (true) {
    // 1. 优先查找是否有完全匹配
    if (context_lang.includes(currentLang)) {
      return currentLang;
    }

    // 2. 查找 major_lang 开头的项 (Prefix match)
    // 例如：currentLang="en", context有一项 "en-US"，则匹配
    const prefixMatch = context_lang.find(lang => lang.startsWith(currentLang));
    if (prefixMatch) {
      return prefixMatch;
    }

    // 3. 拆掉最后一个 "-" 及其后面的内容
    const lastHyphenIndex = currentLang.lastIndexOf('-');
    
    if (lastHyphenIndex !== -1) {
      currentLang = currentLang.substring(0, lastHyphenIndex);
    } else {
      // 没有 "-" 符号了，跳出循环
      break;
    }
  }

  // 4. 依然没有找到，直接返回第一个项
  return context_lang[0];
}
````