### PR TITLE
feat(lyric): 丰富 AMLL 设置项，删除 QM 意外的逐字音译

### DIFF
--- a/src/components/Player/MainAMLyric.vue
+++ b/src/components/Player/MainAMLyric.vue
@@ -76,7 +76,22 @@ const amLyricsData = computed(() => {
   // 简单检查歌词有效性
   if (!Array.isArray(lyrics) || lyrics.length === 0) return [];
 
-  return cloneDeep(lyrics) as LyricLine[];
+  const clonedLyrics = cloneDeep(lyrics) as LyricLine[];
+
+  // 检查是否要不显示某一部分并删去
+  const showTran = settingStore.showTran;
+  const showRoma = settingStore.showRoma;
+  const showWordsRoma = settingStore.showWordsRoma;
+
+  if (!showTran || !showRoma || !showWordsRoma) {
+    clonedLyrics.forEach((line) => {
+      if (!showTran) line.translatedLyric = "";
+      if (!showRoma) line.romanLyric = "";
+      if (!showWordsRoma) line.words.forEach((word) => (word.romanWord = ""));
+    })
+  }
+
+  return clonedLyrics;
 });
 
 // 进度跳转

--- a/src/components/Player/PlayerBackground.vue
+++ b/src/components/Player/PlayerBackground.vue
@@ -23,6 +23,7 @@
         :flowSpeed="flowSpeed"
         :hasLyric="musicStore.isHasLrc"
         :lowFreqVolume="lowFreqVolume"
+        :renderScale="settingStore.playerBackgroundRenderScale ?? 0.5"
       />
     </Transition>
   </div>
@@ -55,8 +56,6 @@ const { pause: pauseRaf, resume: resumeRaf } = useRafFn(
       statusStore.playStatus
     ) {
       lowFreqVolume.value = player.getLowFrequencyVolume();
-    } else {
-      lowFreqVolume.value = 1.0;
     }
   },
   { immediate: false },
@@ -70,8 +69,8 @@ watch(
     statusStore.playStatus,
   ],
   ([enabled, bgType, playing]) => {
-    if (enabled && bgType === "animation" && playing) {
-      resumeRaf();
+    if (enabled && bgType === "animation") {
+      playing ? resumeRaf() : pauseRaf();
     } else {
       pauseRaf();
       lowFreqVolume.value = 1.0;

--- a/src/components/Setting/LyricsSetting.vue
+++ b/src/components/Setting/LyricsSetting.vue
@@ -246,7 +246,6 @@
           v-model:value="settingStore.showTran"
           class="set"
           :round="false"
-          :disabled="settingStore.useAMLyrics"
         />
       </n-card>
       <n-card class="set-item">
@@ -257,7 +256,6 @@
           v-model:value="settingStore.showRoma"
           class="set"
           :round="false"
-          :disabled="settingStore.useAMLyrics"
         />
       </n-card>
       <n-card class="set-item">
@@ -416,6 +414,16 @@
             :min="0.01"
             :max="1"
             :step="0.01"
+            :round="false"
+          />
+        </n-card>
+        <n-card class="set-item">
+          <div class="label">
+            <n-text class="name">显示逐字音译</n-text>
+          </div>
+          <n-switch
+            v-model:value="settingStore.showWordsRoma"
+            class="set"
             :round="false"
           />
         </n-card>

--- a/src/components/Setting/PlaySetting.vue
+++ b/src/components/Setting/PlaySetting.vue
@@ -262,6 +262,23 @@
         </n-card>
         <n-card class="set-item">
           <div class="label">
+            <n-text class="name">背景渲染缩放比例</n-text>
+            <n-text class="tip" :depth="3">设置当前渲染缩放比例，默认 0.5</n-text>
+            <n-text class="tip" :depth="3">
+              适当提高此值（如 1.0 或 1.5）可以减少分界线锯齿，让效果更好，但也会增加显卡压力
+            </n-text>
+          </div>
+          <n-input-number
+            v-model:value="settingStore.playerBackgroundRenderScale"
+            :min="0.1"
+            :max="10"
+            :show-button="false"
+            class="set"
+            placeholder="请输入背景渲染缩放比例"
+          />
+        </n-card>
+        <n-card class="set-item">
+          <div class="label">
             <n-text class="name">背景动画暂停时暂停</n-text>
             <n-text class="tip" :depth="3">在暂停时是否也暂停背景动画</n-text>
           </div>

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -149,6 +149,8 @@ export interface SettingState {
   playerBackgroundPause: boolean;
   /** 背景动画是否响应低频音量 */
   playerBackgroundLowFreqVolume: boolean;
+  /** 背景动画渲染比例 */
+  playerBackgroundRenderScale: number;
   /** 播放器元素自动隐藏 */
   autoHidePlayerMeta: boolean;
   /** 记忆最后进度 */
@@ -359,6 +361,7 @@ export const useSettingStore = defineStore("setting", {
     playerBackgroundFlowSpeed: 4,
     playerBackgroundPause: false,
     playerBackgroundLowFreqVolume: false,
+    playerBackgroundRenderScale: 0.5,
     autoHidePlayerMeta: true,
     memoryLastSeek: true,
     progressTooltipShow: true,

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -67,6 +67,8 @@ export interface SettingState {
   showTran: boolean;
   /** 显示歌词音译 */
   showRoma: boolean;
+  /** 显示逐字音译 */
+  showWordsRoma: boolean;
   /** 歌词位置 */
   lyricsPosition: "flex-start" | "center" | "flex-end";
   /** 歌词滚动位置 */
@@ -385,6 +387,7 @@ export const useSettingStore = defineStore("setting", {
     showYrcAnimation: true,
     showTran: true,
     showRoma: true,
+    showWordsRoma: true,
     lyricsPosition: "flex-start",
     lyricsBlur: false,
     lyricsScrollPosition: "start",


### PR DESCRIPTION
1. 通过删除 `cloneDeep` 后的歌词的翻译和音译来实现了 AMLL 的：不显示翻译、不显示音译、不显示逐字音译
2. 修改了 QM 歌词解析的部分逻辑，合并逐字音译为逐行而不是按 `index` 放入错误的逐字音译（QM 歌词的逐字音译无论从 `index` 还是 `startTime`/`endTime` 都是对不上的，只能合并为逐行）
3. 支持设置 AMLL 背景的 `renderScale`
4. 修改了 AMLL 背景的 `lowFreqVolume` 的逻辑，之前的逻辑会导致暂停后 `lowFreqVolume` 突变为 `1`，现在暂停则会保持