### PR TITLE
🐛fix(lyric)：修复 macOS 切换桌面歌词时的渲染残留问题

### DIFF
--- a/electron/main/windows/lyric-window.ts
+++ b/electron/main/windows/lyric-window.ts
@@ -60,6 +60,7 @@ class LyricWindow {
       x,
       y,
       transparent: true,
+      hasShadow: false,
       backgroundColor: "rgba(0, 0, 0, 0)",
       alwaysOnTop: true,
       resizable: true,


### PR DESCRIPTION
- 通过在窗口创建时设置 'hasShadow: false' 禁用了 macOS 透明窗口的阴影，从而解决了桌面歌词播放过程中随着播放切换歌词时因系统默认淡出动画导致的上句歌词的渲染残留问题。
- 此修改仅针对 macOS 平台，确保了 Windows 和 Linux 平台的原有功能和视觉效果不受任何影响。
- 保留了桌面歌词的透明和锁定穿透核心功能。
