### PR TITLE
fix(audio-player): 修复切歌后播放速率恢复为1

### DIFF
--- a/src/core/audio-player/AudioElementPlayer.ts
+++ b/src/core/audio-player/AudioElementPlayer.ts
@@ -110,6 +110,7 @@ export class AudioElementPlayer extends BaseAudioPlayer {
    */
   public setRate(value: number): void {
     this.audioElement.playbackRate = value;
+    this.audioElement.defaultPlaybackRate = value;
   }
 
   /**


### PR DESCRIPTION
- 在设置播放速率时同时更新 defaultPlaybackRate 属性