### PR TITLE
Fix/apply-chinese-conversion-to-local-lyrics

### DIFF
--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -930,6 +930,7 @@ class LyricManager {
         if (settingStore.enableExcludeLocalLyrics) {
           lyricData = this.handleLyricExclude(lyricData);
         }
+        lyricData = await this.applyChineseVariant(lyricData);
       } else if (song.path) {
         lyricData = await this.handleLocalLyric(song.path);
         // 排除本地歌词内容

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -918,6 +918,7 @@ class LyricManager {
         lyricData = await this.handleStreamingLyric(song);
         // 排除内容
         lyricData = this.handleLyricExclude(lyricData);
+        lyricData = await this.applyChineseVariant(lyricData);
         this.setFinalLyric(lyricData, req);
         return;
       }


### PR DESCRIPTION
为本地歌词和流媒体歌词应用之前遗漏的简繁转换