### PR TITLE
🐛fix(desktop-lyrics): 修复桌面歌词加载时的占位符闪烁问题 

### DIFF
--- a/src/views/DesktopLyric/index.vue
+++ b/src/views/DesktopLyric/index.vue
@@ -214,6 +214,13 @@ const isHovered = ref<boolean>(false);
 // 初始化状态
 const isInitializing = ref(true);
 
+onMounted(() => {
+  // 在组件挂载后短暂延迟，以避免初始内容闪烁
+  setTimeout(() => {
+    isInitializing.value = false;
+  }, 250);
+});
+
 const { start: startHoverTimer } = useTimeoutFn(
   () => {
     isHovered.value = false;
@@ -304,6 +311,11 @@ const getLineTop = (index: number) => {
  * @returns 渲染的歌词行数组
  */
 const renderLyricLines = computed<RenderLine[]>(() => {
+  // 在初始化阶段，不渲染任何内容
+  if (isInitializing.value) {
+    return [];
+  }
+
   const lyrics =
     lyricConfig.showYrc && lyricData?.yrcData?.length ? lyricData.yrcData : lyricData.lrcData;
   // 无歌曲名且无歌词

--- a/src/views/DesktopLyric/index.vue
+++ b/src/views/DesktopLyric/index.vue
@@ -214,12 +214,6 @@ const isHovered = ref<boolean>(false);
 // 初始化状态
 const isInitializing = ref(true);
 
-onMounted(() => {
-  // 在组件挂载后短暂延迟，以避免初始内容闪烁
-  setTimeout(() => {
-    isInitializing.value = false;
-  }, 250);
-});
 
 const { start: startHoverTimer } = useTimeoutFn(
   () => {
@@ -784,7 +778,7 @@ onMounted(() => {
   // 延迟结束初始化状态
   useTimeoutFn(() => {
     isInitializing.value = false;
-  }, 500);
+  }, 250);
 
   // 启动 RAF 插值
   if (lyricData.playStatus) {

--- a/src/views/DesktopLyric/index.vue
+++ b/src/views/DesktopLyric/index.vue
@@ -152,6 +152,8 @@ import { LyricLine, LyricWord } from "@applemusic-like-lyrics/lyric";
 import { LyricConfig, LyricData, RenderLine } from "@/types/desktop-lyric";
 import defaultDesktopLyricConfig from "@/assets/data/lyricConfig";
 
+const INITIALIZATION_DELAY = 250; // 歌词窗口初始化延迟，用于防止闪烁
+
 // 桌面歌词数据
 const lyricData = reactive<LyricData>({
   playName: "",
@@ -778,7 +780,7 @@ onMounted(() => {
   // 延迟结束初始化状态
   useTimeoutFn(() => {
     isInitializing.value = false;
-  }, 250);
+  }, INITIALIZATION_DELAY);
 
   // 启动 RAF 插值
   if (lyricData.playStatus) {


### PR DESCRIPTION
**如图**
![截屏2026-01-30 16.09.23.png](https://youke.xn--y7xa690gmna.cn/s1/2026/01/30/697c8035239e7.webp)

**问题现象**
在加载实际歌词或歌曲状态之前，桌面歌词窗口会先渲染一个初始的占位符 `SPlayer Desktop Lyric`，导致视觉上的闪烁。

**修复方案**
通过在桌面歌词组件 `DesktopLyric/index.vue` 中引入一个短暂的“初始化”阶段来解决此问题：

- **加载时屏蔽渲染**：在组件挂载后的最初 250ms 内，不渲染任何内容，从根源上避免了闪烁。

- **恢复正常逻辑**：初始化阶段结束后，组件恢复其原始的渲染逻辑。

此方案精确地区分了“加载中的短暂空白”和“无歌名且无歌词”状态，在彻底解决闪烁问题的同时，保留了原有的预期功能。