### PR TITLE
refactor(setting): 改动设置

### DIFF
--- a/src/components/Setting/config/appearance.ts
+++ b/src/components/Setting/config/appearance.ts
@@ -12,6 +12,7 @@ import {
 import { SettingConfig } from "@/types/settings";
 import { computed, ref } from "vue";
 import { isLogin } from "@/utils/auth";
+import { forceDisplaySettingIf } from "@/utils/setting";
 
 export const useAppearanceSettings = (): SettingConfig => {
   const settingStore = useSettingStore();
@@ -47,19 +48,20 @@ export const useAppearanceSettings = (): SettingConfig => {
             key: "themeMode",
             label: "主题模式",
             type: "select",
-            description: () =>
-              statusStore.themeBackgroundMode === "image"
-                ? "请关闭自定义背景图后调节"
-                : "调整全局主题明暗模式",
-            disabled: computed(() => statusStore.themeBackgroundMode === "image"),
             options: [
               { label: "跟随系统", value: "auto" },
               { label: "浅色模式", value: "light" },
               { label: "深色模式", value: "dark" },
             ],
-            value: computed({
-              get: () => settingStore.themeMode,
-              set: (v) => (settingStore.themeMode = v),
+            ...forceDisplaySettingIf({
+              condition: () => statusStore.themeBackgroundMode === "image",
+              displayValue: "auto" as const,
+              value: {
+                get: () => settingStore.themeMode,
+                set: (v) => (settingStore.themeMode = v),
+              },
+              description: "调整全局主题明暗模式",
+              descriptionDisabled: "请关闭自定义背景图后调节",
             }),
           },
           {
@@ -238,6 +240,7 @@ export const useAppearanceSettings = (): SettingConfig => {
               get: () => settingStore.playerBackgroundType,
               set: (v) => (settingStore.playerBackgroundType = v),
             }),
+            condition: () => settingStore.playerBackgroundType === "animation",
             children: [
               {
                 key: "playerBackgroundFps",
@@ -332,10 +335,14 @@ export const useAppearanceSettings = (): SettingConfig => {
             label: "动态封面",
             type: "switch",
             description: "可展示部分歌曲的动态封面，仅在封面模式有效",
-            disabled: () => isLogin() !== 1,
-            value: computed({
-              get: () => settingStore.dynamicCover,
-              set: (v) => (settingStore.dynamicCover = v),
+            ...forceDisplaySettingIf({
+              condition: () => isLogin() !== 1,
+              displayValue: false,
+              value: {
+                get: () => settingStore.dynamicCover,
+                set: (v) => (settingStore.dynamicCover = v),
+              },
+              titleDisabled: "正常登录账号后才能开启"
             }),
           },
           {
@@ -343,14 +350,15 @@ export const useAppearanceSettings = (): SettingConfig => {
             label: "音乐频谱",
             type: "switch",
             show: isElectron,
-            description:
-              settingStore.playbackEngine === "mpv"
-                ? "MPV 引擎暂不支持显示音乐频谱"
-                : "开启音乐频谱会影响性能或增加内存占用，如遇问题请关闭",
-            disabled: () => settingStore.playbackEngine === "mpv",
-            value: computed({
-              get: () => settingStore.showSpectrums,
-              set: (v) => (settingStore.showSpectrums = v),
+            description: "开启音乐频谱会影响性能或增加内存占用，如遇问题请关闭",
+            ...forceDisplaySettingIf({
+              condition: () => settingStore.playbackEngine === "mpv",
+              displayValue: false,
+              value: {
+                get: () => settingStore.showSpectrums,
+                set: (v) => (settingStore.showSpectrums = v),
+              },
+              titleDisabled: "MPV 引擎暂不支持显示音乐频谱"
             }),
           },
         ],

--- a/src/components/Setting/config/lyric.ts
+++ b/src/components/Setting/config/lyric.ts
@@ -7,23 +7,12 @@ import { cloneDeep, isEqual } from "lodash-es";
 import defaultDesktopLyricConfig from "@/assets/data/lyricConfig";
 import { SettingConfig } from "@/types/settings";
 import LyricPreview from "../components/LyricPreview.vue";
+import { descMultiline, forceDisplaySettingIf } from "@/utils/setting";
 
 export const useLyricSettings = (): SettingConfig => {
   const player = usePlayerController();
   const statusStore = useStatusStore();
   const settingStore = useSettingStore();
-
-  const fontSizeComputed = (key: string) =>
-    computed({
-      get: () =>
-        settingStore.useAMLyrics
-          ? Math.max(0.5 * settingStore.lyricFontSize, 10)
-          : settingStore[key],
-      set: (value) => (settingStore[key] = value),
-    });
-
-  const tranFontSize = fontSizeComputed("lyricTranFontSize");
-  const romaFontSize = fontSizeComputed("lyricRomaFontSize");
 
   // 桌面歌词配置
   const desktopLyricConfig = reactive<LyricConfig>({ ...defaultDesktopLyricConfig });
@@ -123,13 +112,16 @@ export const useLyricSettings = (): SettingConfig => {
             min: 5,
             max: 40,
             suffix: "px",
-            disabled: computed(() => settingStore.useAMLyrics),
-            title: computed(() => (settingStore.useAMLyrics ? "由 AMLL 自动控制" : "")),
-            value: computed({
-              get: () => tranFontSize.value,
-              set: (v) => (tranFontSize.value = v || 22),
-            }),
             defaultValue: 22,
+            ...forceDisplaySettingIf({
+              condition: () => settingStore.useAMLyrics,
+              displayValue: () => Math.max(0.5 * settingStore.lyricFontSize, 10),
+              value: {
+                get: () => settingStore.lyricTranFontSize,
+                set: (v) => (settingStore.lyricTranFontSize = v || 22),
+              },
+              titleDisabled: "由 AMLL 自动控制",
+            }),
           },
           {
             key: "lyricRomaFontSize",
@@ -139,13 +131,16 @@ export const useLyricSettings = (): SettingConfig => {
             min: 5,
             max: 40,
             suffix: "px",
-            disabled: computed(() => settingStore.useAMLyrics),
-            title: computed(() => (settingStore.useAMLyrics ? "由 AMLL 自动控制" : "")),
-            value: computed({
-              get: () => romaFontSize.value,
-              set: (v) => (romaFontSize.value = v || 18),
-            }),
             defaultValue: 18,
+            ...forceDisplaySettingIf({
+              condition: () => settingStore.useAMLyrics,
+              displayValue: () => Math.max(0.5 * settingStore.lyricFontSize, 10),
+              value: {
+                get: () => settingStore.lyricRomaFontSize,
+                set: (v) => (settingStore.lyricRomaFontSize = v || 18),
+              },
+              titleDisabled: "由 AMLL 自动控制",
+            }),
           },
           {
             key: "fontConfig",
@@ -172,16 +167,20 @@ export const useLyricSettings = (): SettingConfig => {
             key: "lyricsPosition",
             label: "歌词位置",
             type: "select",
-            description: "歌词的默认垂直位置",
-            disabled: computed(() => settingStore.useAMLyrics),
             options: [
               { label: "居左", value: "flex-start" },
               { label: "居中", value: "center" },
               { label: "居右", value: "flex-end" },
             ],
-            value: computed({
-              get: () => settingStore.lyricsPosition,
-              set: (v) => (settingStore.lyricsPosition = v),
+            ...forceDisplaySettingIf({
+              condition: () => settingStore.useAMLyrics,
+              displayValue: "flex-start" as const,
+              value: {
+                get: () => settingStore.lyricsPosition,
+                set: (v) => (settingStore.lyricsPosition = v),
+              },
+              description: "歌词的默认垂直位置",
+              descriptionDisabled: "歌词的默认垂直位置，AMLL 默认只可居左",
             }),
           },
           {
@@ -209,51 +208,6 @@ export const useLyricSettings = (): SettingConfig => {
               set: (v) => (settingStore.lyricAlignRight = v),
             }),
           },
-          {
-            key: "replaceLyricBrackets",
-            label: "替换歌词括号内容",
-            type: "switch",
-            description: "将歌词中的括号内容替换为指定格式",
-            value: computed({
-              get: () => settingStore.replaceLyricBrackets,
-              set: (v) => (settingStore.replaceLyricBrackets = v),
-            }),
-          },
-          {
-            key: "bracketReplacementPreset",
-            label: "括号替换样式",
-            type: "select",
-            description: "选择替换后的括号样式",
-            disabled: computed(() => !settingStore.replaceLyricBrackets),
-            options: [
-              { label: "连字符 ( - )", value: "dash" },
-              { label: "六角括号 (〔 〕)", value: "angleBrackets" },
-              { label: "直角引号 (「 」)", value: "cornerBrackets" },
-              { label: "自定义", value: "custom" },
-            ],
-            value: computed({
-              get: () => settingStore.bracketReplacementPreset,
-              set: (v) => (settingStore.bracketReplacementPreset = v),
-            }),
-          },
-          {
-            key: "customBracketReplacement",
-            label: "自定义替换内容",
-            type: "text-input",
-            description: "输入自定义的替换字符。支持单个分隔符（如 - ）或成对符号（如 () ）",
-            disabled: computed(() => !settingStore.replaceLyricBrackets || settingStore.bracketReplacementPreset !== "custom"),
-            value: computed({
-              get: () => settingStore.customBracketReplacement,
-              set: (v) => {
-                if (v.trim().length > 5) {
-                  window.$message.warning("自定义替换内容不能超过5个字符");
-                  return;
-                }
-                settingStore.customBracketReplacement = v;
-              },
-            }),
-          },
-
           {
             key: "lyricsScrollOffset",
             label: "歌词滚动位置",
@@ -326,10 +280,13 @@ export const useLyricSettings = (): SettingConfig => {
             label: "调换翻译与音译位置",
             type: "switch",
             description: "开启后音译显示在翻译上方",
-            disabled: computed(() => !settingStore.showTran || !settingStore.showRoma),
-            value: computed({
-              get: () => settingStore.swapTranRoma,
-              set: (v) => (settingStore.swapTranRoma = v),
+            ...forceDisplaySettingIf({
+              condition: () => !settingStore.showTran || !settingStore.showRoma,
+              displayValue: false,
+              value: computed({
+                get: () => settingStore.swapTranRoma,
+                set: (v) => (settingStore.swapTranRoma = v),
+              }),
             }),
           },
           {
@@ -412,6 +369,53 @@ export const useLyricSettings = (): SettingConfig => {
             ],
           },
           {
+            key: "replaceLyricBrackets",
+            label: "替换歌词括号内容",
+            type: "switch",
+            description: "将歌词中的括号内容替换为指定格式",
+            value: computed({
+              get: () => settingStore.replaceLyricBrackets,
+              set: (v) => (settingStore.replaceLyricBrackets = v),
+            }),
+            children: [
+              {
+                key: "bracketReplacementPreset",
+                label: "括号替换样式",
+                type: "select",
+                description: "选择替换后的括号样式",
+                options: [
+                  { label: "连字符 ( - )", value: "dash" },
+                  { label: "六角括号 (〔 〕)", value: "angleBrackets" },
+                  { label: "直角引号 (「 」)", value: "cornerBrackets" },
+                  { label: "自定义", value: "custom" },
+                ],
+                value: computed({
+                  get: () => settingStore.bracketReplacementPreset,
+                  set: (v) => (settingStore.bracketReplacementPreset = v),
+                }),
+                condition: () => settingStore.bracketReplacementPreset === "custom",
+                children: [
+                  {
+                    key: "customBracketReplacement",
+                    label: "自定义替换内容",
+                    type: "text-input",
+                    description: "输入自定义的替换字符。支持单个分隔符（如 - ）或成对符号（如 () ）",
+                    value: computed({
+                      get: () => settingStore.customBracketReplacement,
+                      set: (v) => {
+                        if (v.trim().length > 5) {
+                          window.$message.warning("自定义替换内容不能超过5个字符");
+                          return;
+                        }
+                        settingStore.customBracketReplacement = v;
+                      },
+                    }),
+                  },
+                ],
+              },
+            ],
+          },
+          {
             key: "configExcludeLyric",
             label: "歌词排除配置",
             type: "button",
@@ -459,8 +463,13 @@ export const useLyricSettings = (): SettingConfig => {
                 key: "wordFadeWidth",
                 label: "文字动画的渐变宽度",
                 type: "input-number",
-                description:
-                  "单位以歌词行的主文字字体大小的倍数为单位 <br /> 默认为 0.5，即一个全角字符的一半宽度 <br /> 若模拟 Apple Music for Android 的效果，可以设为 1 <br /> 若模拟 Apple Music for iPad 的效果，可以设为 0.5 <br /> 若需近乎禁用渐变，可设为非常接近 0 的小数，如 0.01",
+                description: descMultiline`
+                  单位以歌词行的主文字字体大小的倍数为单位
+                  默认为 0.5，即一个全角字符的一半宽度
+                  若模拟 Apple Music for Android 的效果，可以设为 1
+                  若模拟 Apple Music for iPad 的效果，可以设为 0.5
+                  若需近乎禁用渐变，可设为非常接近 0 的小数，如 0.01
+                `,
                 min: 0.01,
                 max: 1,
                 step: 0.01,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -366,3 +366,27 @@ export const getPlayerInfo = (song?: SongType, sep: string = "/"): string | null
   if (!info) return null;
   return `${info.name} - ${info.artist}`;
 };
+
+/**
+ * 检测所有输入行的共同最小缩进，将其从每一行中删除，如果第一行和最后一行是空白行，也将其删除
+ * @param string 字符串
+ * @param newline 换行符
+ * @returns 去除缩进后的字符串
+ */
+export const trimIndentString = (string: string, newline: string = "\n"): string => {
+  if (!string) return "";
+  const lines = string.split(newline);
+  // 删除第一行和最后一行的空白行
+  const relevantLines = lines.filter(
+    (line, index) => (index !== 0 && index !== lines.length - 1) || line.trim() !== "",
+  );
+  // 移除每行的最小缩进
+  const minIndent = relevantLines
+    .filter((line) => line.trim() !== "")
+    .map((line) => line.match(/^\s*/)?.[0].length ?? 0)
+    .reduce((min, indent) => Math.min(min, indent), Infinity);
+  const trimmedLines = relevantLines.map((line) => {
+    return line.slice(minIndent);
+  });
+  return trimmedLines.join(newline);
+};

--- a/src/utils/setting.ts
+++ b/src/utils/setting.ts
@@ -1,0 +1,61 @@
+import { trimIndentString } from "@/utils/format";
+
+/**
+ * 当条件满足时，禁用设置项并强制显示为某值
+ * @param options.condition 条件，当为 true 时禁用设置项并强制显示为某值
+ * @param options.displayValue 当条件满足时强制显示的值
+ * @param options.value 原始值
+ * @param options.title 鼠标悬停时的文字（需配合 `titleDisabled` 一起使用，否则会被忽略，此时将此值放在此函数外部）
+ * @param options.titleDisabled 被禁用时鼠标悬停显示的提示文字
+ * @param options.description 描述文字（需配合 `descriptionDisabled` 一起使用，同上）
+ * @param options.descriptionDisabled 被禁用时显示的描述文字
+ */
+export const forceDisplaySettingIf = <T>(options: {
+  condition: MaybeRefOrGetter<boolean>;
+  displayValue: MaybeRefOrGetter<T>;
+  value: { get: () => T; set: (v: T) => void } | WritableComputedRef<T> | Ref<T>;
+  title?: MaybeRefOrGetter<string>;
+  titleDisabled?: MaybeRefOrGetter<string>;
+  description?: MaybeRefOrGetter<string>;
+  descriptionDisabled?: MaybeRefOrGetter<string>;
+}): {
+  disabled: ComputedRef<boolean>;
+  title?: ComputedRef<string>;
+  description?: ComputedRef<string>;
+  value: ComputedRef<T>;
+} => {
+  const { condition, displayValue, value, title, titleDisabled, description, descriptionDisabled } =
+    options;
+  const conditionRef = computed(() => toValue(condition));
+
+  const getter: () => T =
+    "get" in value && typeof value.get === "function"
+      ? (value.get as () => T)
+      : () => toValue(value as Ref<T>);
+  const setter: (v: T) => void =
+    "set" in value && typeof value.set === "function"
+      ? (value.set as (v: T) => void)
+      : (v: T) => ((value as Ref<T>).value = v);
+
+  const result: any = {
+    disabled: conditionRef,
+    value: computed({
+      get: () => (conditionRef.value ? toValue(displayValue) : getter()),
+      set: (v) => setter(v),
+    }),
+  };
+
+  if (titleDisabled)
+    result.title = computed(() => (conditionRef.value ? toValue(titleDisabled) : toValue(title)));
+  if (descriptionDisabled)
+    result.description = computed(() =>
+      conditionRef.value ? toValue(descriptionDisabled) : toValue(description),
+    );
+
+  return result;
+};
+
+export const descMultiline = (strings: TemplateStringsArray, ...values: any[]): string => {
+  const fullString = String.raw(strings, ...values);
+  return trimIndentString(fullString).replace(/\n/g, "<br />");
+};


### PR DESCRIPTION
让多行设置描述的代码更易读，增加 `descMultiline` 模板字符串标签函数

修复流体效果设置项未显示

将「替换歌词括号内容」设置项移至「歌词内容」组

为「当条件满足时，禁用设置项并强制显示为某值」这一常见需求提供了工具函数 `forceDisplaySettingIf`