### PR TITLE
feat: 避免含有标题的较短本地音乐因时长或文件大小而被排除

### DIFF
--- a/electron/main/services/LocalMusicService.ts
+++ b/electron/main/services/LocalMusicService.ts
@@ -10,6 +10,9 @@ import { LocalMusicDB, type MusicTrack } from "../database/LocalMusicDB";
 import FastGlob, { type Entry } from "fast-glob";
 import pLimit from "p-limit";
 
+const UNTITLED_TRACK_MIN_DURATION = 30; // seconds
+const UNTITLED_TRACK_MIN_SIZE = 1024 * 1024; // 1MB
+
 /** 本地音乐服务 */
 export class LocalMusicService {
   /** 数据库实例 */
@@ -230,9 +233,9 @@ export class LocalMusicService {
             // 仅当无标题时才过滤
             if (!metadata.common.title) {
               // 时长 < 30s
-              if (metadata.format.duration && metadata.format.duration < 30) return;
+              if (metadata.format.duration && metadata.format.duration < UNTITLED_TRACK_MIN_DURATION) return;
               // 大小 < 1MB
-              if (size < 1024 * 1024) return;
+              if (size < UNTITLED_TRACK_MIN_SIZE) return;
             }
             // 提取封面
             const coverPath = await this.extractCover(metadata, id);

--- a/electron/main/services/LocalMusicService.ts
+++ b/electron/main/services/LocalMusicService.ts
@@ -231,8 +231,6 @@ export class LocalMusicService {
             if (!metadata.common.title) {
               // 时长 < 30s
               if (metadata.format.duration && metadata.format.duration < 30) return;
-              // 时长 > 2h (7200s)
-              if (metadata.format.duration && metadata.format.duration > 7200) return;
               // 大小 < 1MB
               if (size < 1024 * 1024) return;
             }

--- a/electron/main/services/LocalMusicService.ts
+++ b/electron/main/services/LocalMusicService.ts
@@ -193,8 +193,6 @@ export class LocalMusicService {
           const mtime = stats.mtimeMs;
           /** 文件大小 */
           const size = stats.size;
-          // 小于 1MB 的文件不处理
-          if (size < 1024 * 1024) return;
           scannedPaths.add(filePath);
 
           /** 缓存 */
@@ -229,10 +227,15 @@ export class LocalMusicService {
             const id = this.getFileId(filePath);
             const metadata = await parseFile(filePath);
             // 过滤规则
-            // 时长 < 30s
-            if (metadata.format.duration && metadata.format.duration < 30) return;
-            // 时长 > 2h (7200s)
-            if (metadata.format.duration && metadata.format.duration > 7200) return;
+            // 仅当无标题时才过滤
+            if (!metadata.common.title) {
+              // 时长 < 30s
+              if (metadata.format.duration && metadata.format.duration < 30) return;
+              // 时长 > 2h (7200s)
+              if (metadata.format.duration && metadata.format.duration > 7200) return;
+              // 大小 < 1MB
+              if (size < 1024 * 1024) return;
+            }
             // 提取封面
             const coverPath = await this.extractCover(metadata, id);
             // 构建音乐数据


### PR DESCRIPTION
在一些专辑中（如*Exhale EP - Devin Wild*）会有作为过渡的短小间奏曲目。这些曲目的本地文件往往时长小于30秒或者文件大小小于1MB从而会被本地曲目扫描器排除。但这些曲目作为专辑的一部分不应被排除。

**解决方案**：仅当确认本地文件没有标题时将过短或过小的音频文件过滤，避免误伤短小曲目。