### PR TITLE
Fix/wrong-native-configuration

### DIFF
--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -37,7 +37,7 @@ const config: Configuration = {
     },
     {
       from: "native/tools",
-      to: "tools",
+      to: "native",
       filter: ["*.node"],
     },
   ],

--- a/native/tools/src/scanner.rs
+++ b/native/tools/src/scanner.rs
@@ -304,7 +304,7 @@ fn process_single_track(
         cover: cover_path,
         mtime,
         size,
-        bitrate: f64::from(properties.audio_bitrate().unwrap_or(0)),
+        bitrate: f64::from(properties.audio_bitrate().unwrap_or(0) * 1000),
     })
 }
 

--- a/native/tools/src/scanner.rs
+++ b/native/tools/src/scanner.rs
@@ -294,6 +294,8 @@ fn process_single_track(
     let id = get_file_id(&path_str);
     let cover_path = process_cover(&tagged_file, &id, cover_dir_path);
 
+    let bitrate_kbps = properties.audio_bitrate().unwrap_or(0);
+
     Some(MusicTrack {
         id,
         path: path_str,
@@ -304,7 +306,7 @@ fn process_single_track(
         cover: cover_path,
         mtime,
         size,
-        bitrate: f64::from(properties.audio_bitrate().unwrap_or(0) * 1000),
+        bitrate: f64::from(bitrate_kbps) * 1000.0,
     })
 }
 


### PR DESCRIPTION
修复了打包找不到tools原生模块和rust侧传给JS端的单位错误导致只显示LQ质量的bug