### PR TITLE
🦄 refactor: 改善任务栏歌词兼容性

### DIFF
--- a/native/taskbar-lyric/src/strategy/win11.rs
+++ b/native/taskbar-lyric/src/strategy/win11.rs
@@ -15,7 +15,7 @@ use crate::{
     LayoutParams, TaskbarStrategy,
     strategy::{Rect, TaskbarLayout, Win11Layout},
     uia::TaskbarScanner,
-    utils::{check_registry_value, find_taskbar_hwnd, modify_window_long},
+    utils::{BRIDGE_CLASS, check_registry_value, find_taskbar_hwnd, modify_window_long},
 };
 
 pub struct Win11Strategy {
@@ -38,13 +38,23 @@ impl Win11Strategy {
 
 impl TaskbarStrategy for Win11Strategy {
     fn init(&mut self) -> bool {
-        if let Some(hwnd) = find_taskbar_hwnd() {
-            self.h_taskbar = hwnd;
-            debug!(?hwnd, "找到 Shell_TrayWnd");
-            return true;
+        let Some(hwnd) = find_taskbar_hwnd() else {
+            error!("初始化失败，找不到 Shell_TrayWnd");
+            return false;
+        };
+
+        unsafe {
+            let h_bridge = FindWindowExW(Some(hwnd), None, BRIDGE_CLASS, None).unwrap_or_default();
+
+            if h_bridge.0.is_null() {
+                error!("初始化失败，找不到 XAML 桥");
+                return false;
+            }
         }
-        error!("初始化失败，找不到 Shell_TrayWnd");
-        false
+
+        self.h_taskbar = hwnd;
+        debug!(?hwnd, "Win11 策略初始化成功");
+        true
     }
 
     fn embed_window(&self, child_wnd: HWND) -> bool {

--- a/native/taskbar-lyric/src/strategy/win11.rs
+++ b/native/taskbar-lyric/src/strategy/win11.rs
@@ -43,13 +43,12 @@ impl TaskbarStrategy for Win11Strategy {
             return false;
         };
 
-        unsafe {
-            let h_bridge = FindWindowExW(Some(hwnd), None, BRIDGE_CLASS, None).unwrap_or_default();
+        let h_bridge =
+            unsafe { FindWindowExW(Some(hwnd), None, BRIDGE_CLASS, None) }.unwrap_or_default();
 
-            if h_bridge.0.is_null() {
-                error!("初始化失败，找不到 XAML 桥");
-                return false;
-            }
+        if h_bridge.0.is_null() {
+            error!("初始化失败，找不到 XAML 桥");
+            return false;
         }
 
         self.h_taskbar = hwnd;

--- a/native/taskbar-lyric/src/uia.rs
+++ b/native/taskbar-lyric/src/uia.rs
@@ -1,24 +1,20 @@
 use anyhow::{Context, Result, bail};
-use windows::{
-    Win32::{
-        Foundation::{HWND, RPC_E_CHANGED_MODE},
-        System::Com::{
-            CLSCTX_INPROC_SERVER, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx,
-            CoUninitialize,
-        },
-        UI::{
-            Accessibility::{
-                CUIAutomation, IUIAutomation, IUIAutomationElement, TreeScope_Descendants,
-            },
-            WindowsAndMessaging::FindWindowExW,
-        },
+use windows::Win32::{
+    Foundation::{HWND, RPC_E_CHANGED_MODE},
+    System::Com::{
+        CLSCTX_INPROC_SERVER, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx,
+        CoUninitialize,
     },
-    core::{PCWSTR, w},
+    UI::{
+        Accessibility::{
+            CUIAutomation, IUIAutomation, IUIAutomationElement, TreeScope_Descendants,
+        },
+        WindowsAndMessaging::FindWindowExW,
+    },
 };
 
-use crate::strategy::Rect;
+use crate::{strategy::Rect, utils::BRIDGE_CLASS};
 
-const BRIDGE_CLASS: PCWSTR = w!("Windows.UI.Composition.DesktopWindowContentBridge");
 const CLASS_TASKLIST_BUTTON: &str = "Taskbar.TaskListButtonAutomationPeer";
 const ID_START_BUTTON: &str = "StartButton";
 const ID_SEARCH_BUTTON: &str = "SearchButton";

--- a/native/taskbar-lyric/src/utils.rs
+++ b/native/taskbar-lyric/src/utils.rs
@@ -11,10 +11,13 @@ use windows::{
     },
     core::w,
 };
+use windows_core::PCWSTR;
 use winreg::{
     RegKey,
     enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE},
 };
+
+pub const BRIDGE_CLASS: PCWSTR = w!("Windows.UI.Composition.DesktopWindowContentBridge");
 
 pub const REG_KEY_ADVANCED: &str =
     "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced";


### PR DESCRIPTION
改善了任务栏歌词在面对魔改任务栏时的兼容性，现在如果用户在 Windows 11 上使用 Windows 10 的任务栏，应该可以回退到 Windows 10 的实现了