### PR TITLE
perf(MediaSessionManager): 减少时间线更新的节流间隔

### DIFF
--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -25,7 +25,7 @@ class MediaSessionManager {
 
   private throttledSendTimeline = throttle((currentTime: number, duration: number) => {
     sendMediaTimeline(currentTime, duration);
-  }, 1000);
+  }, 200);
 
   /**
    * 是否使用原生媒体集成


### PR DESCRIPTION
在 MPRIS 上，播放进度有时会有一些奇怪的延迟（最多慢 1~2s）

我尝试降低节流间隔，发现此问题有明显缓解（在我的电脑上测试 3 天，延迟被降低至 1s 以内）

此更改不应影响其他行为，包括其他操作系统的行为，也不应造成性能问题