### PR TITLE
🦄 refactor: 移除阻塞调用以加快应用关闭

### DIFF
--- a/native/taskbar-lyric/src/lib.rs
+++ b/native/taskbar-lyric/src/lib.rs
@@ -287,7 +287,6 @@ impl RegistryWatcher {
             .is_err()
             {
                 error!("打开注册表键失败");
-                let _ = CloseHandle(stop_event);
                 return;
             }
 
@@ -296,7 +295,6 @@ impl RegistryWatcher {
                 Err(e) => {
                     error!("创建注册表事件失败: {e}");
                     let _ = RegCloseKey(h_key);
-                    let _ = CloseHandle(stop_event);
                     return;
                 }
             };

--- a/native/taskbar-lyric/src/lib.rs
+++ b/native/taskbar-lyric/src/lib.rs
@@ -255,10 +255,9 @@ impl RegistryWatcher {
     }
 
     #[napi]
-    #[allow(clippy::missing_errors_doc)]
-    pub fn stop(&mut self) -> napi::Result<()> {
+    pub fn stop(&mut self) {
         if !self.is_running.load(Ordering::SeqCst) {
-            return Ok(());
+            return;
         }
 
         unsafe {
@@ -267,7 +266,6 @@ impl RegistryWatcher {
 
         self.is_running.store(false, Ordering::SeqCst);
         info!("注册表监听已停止");
-        Ok(())
     }
 
     unsafe fn watch_loop(stop_event_wrapper: &Arc<EventHandle>, callback: &ThreadsafeFunction<()>) {
@@ -336,5 +334,11 @@ impl RegistryWatcher {
             let _ = CloseHandle(reg_event);
             let _ = RegCloseKey(h_key);
         }
+    }
+}
+
+impl Drop for RegistryWatcher {
+    fn drop(&mut self) {
+        self.stop();
     }
 }

--- a/native/taskbar-lyric/src/tray_watcher.rs
+++ b/native/taskbar-lyric/src/tray_watcher.rs
@@ -123,6 +123,12 @@ impl NativeTrayWatcher {
     }
 }
 
+impl Drop for NativeTrayWatcher {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
 #[napi]
 pub struct TrayWatcher {
     inner: Option<NativeTrayWatcher>,

--- a/native/taskbar-lyric/src/tray_watcher.rs
+++ b/native/taskbar-lyric/src/tray_watcher.rs
@@ -56,7 +56,6 @@ unsafe extern "system" fn win_event_proc(
 
 pub struct NativeTrayWatcher {
     thread_id: Option<u32>,
-    thread_handle: Option<thread::JoinHandle<()>>,
 }
 
 impl NativeTrayWatcher {
@@ -69,7 +68,7 @@ impl NativeTrayWatcher {
 
         let (tx, rx) = std::sync::mpsc::channel();
 
-        let handle = thread::spawn(move || unsafe {
+        thread::spawn(move || unsafe {
             let current_tid = GetCurrentThreadId();
             let _ = tx.send(current_tid);
 
@@ -111,7 +110,6 @@ impl NativeTrayWatcher {
 
         Ok(Self {
             thread_id: Some(thread_id),
-            thread_handle: Some(handle),
         })
     }
 
@@ -121,10 +119,6 @@ impl NativeTrayWatcher {
                 let _ = PostThreadMessageW(tid, WM_QUIT, WPARAM(0), LPARAM(0));
             }
             self.thread_id = None;
-        }
-
-        if let Some(handle) = self.thread_handle.take() {
-            let _ = handle.join();
         }
     }
 }

--- a/native/taskbar-lyric/src/uia_watcher.rs
+++ b/native/taskbar-lyric/src/uia_watcher.rs
@@ -90,7 +90,6 @@ impl IUIAutomationStructureChangedEventHandler_Impl for TaskbarEventHandler_Impl
 
 pub struct NativeUiaWatcher {
     thread_id: Option<u32>,
-    thread_handle: Option<thread::JoinHandle<()>>,
 }
 
 impl NativeUiaWatcher {
@@ -98,7 +97,7 @@ impl NativeUiaWatcher {
         let (tx, rx) = mpsc::channel::<u32>();
         let callback_arc = Arc::new(callback);
 
-        let handle = thread::spawn(move || unsafe {
+        thread::spawn(move || unsafe {
             let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
 
             let thread_id = GetCurrentThreadId();
@@ -156,7 +155,6 @@ impl NativeUiaWatcher {
 
         Ok(Self {
             thread_id: Some(thread_id),
-            thread_handle: Some(handle),
         })
     }
 
@@ -166,10 +164,6 @@ impl NativeUiaWatcher {
                 let _ = PostThreadMessageW(tid, WM_QUIT, WPARAM(0), LPARAM(0));
             }
             self.thread_id = None;
-        }
-
-        if let Some(handle) = self.thread_handle.take() {
-            let _ = handle.join();
         }
     }
 }


### PR DESCRIPTION
移除任务栏歌词模块中的阻塞调用以加快应用关闭

现在 Rust 线程会分离并自行关闭，而不是让 Electron 主线程等待 Rust 线程关闭才能关闭
