### PR TITLE
feat(EMI): 播放速率的基础实现

### DIFF
--- a/electron/main/ipc/ipc-media.ts
+++ b/electron/main/ipc/ipc-media.ts
@@ -77,6 +77,16 @@ const initMediaIpc = () => {
     }
   });
 
+  // 播放速率更新
+  ipcMain.on("media-update-playback-rate", (_, payload: { rate: number }) => {
+    if (!emi) return;
+    try {
+      emi.updatePlaybackRate(payload.rate);
+    } catch (e) {
+      processLog.error("[Media] 更新播放速率失败", e);
+    }
+  });
+
   // 进度更新
   ipcMain.on("media-update-timeline", (_, payload: TimelinePayload) => {
     if (!emi) return;

--- a/native/external-media-integration/index.d.ts
+++ b/native/external-media-integration/index.d.ts
@@ -136,6 +136,7 @@ export declare function shutdown(): void
 export interface SystemMediaEvent {
   type: SystemMediaEventType
   positionMs?: number
+  rate?: number
 }
 
 export type SystemMediaEventType =  'Play'|
@@ -145,6 +146,7 @@ export type SystemMediaEventType =  'Play'|
 'PreviousSong'|
 'ToggleShuffle'|
 'ToggleRepeat'|
+'SetRate'|
 /** 绝对位置，毫秒 */
 'Seek';
 
@@ -175,6 +177,15 @@ export declare function updateDiscordConfig(payload: DiscordConfigPayload): void
  * 更新 Discord RPC 的元数据时，必须提供 `original_cover_url`
  */
 export declare function updateMetadata(payload: MetadataParam): void
+
+/**
+ * 更新播放速率
+ *
+ * ### 备注
+ *
+ * 只会更新媒体控件的信息，不会更新 Discord RPC 上的信息
+ */
+export declare function updatePlaybackRate(rate: number): void
 
 /**
  * 更新播放模式

--- a/native/external-media-integration/src/lib.rs
+++ b/native/external-media-integration/src/lib.rs
@@ -127,6 +127,16 @@ pub fn update_play_state(payload: PlayStatePayload) {
     sys_media::get_platform_controls().update_playback_status(payload);
 }
 
+/// 更新播放速率
+///
+/// ### 备注
+///
+/// 只会更新媒体控件的信息，不会更新 Discord RPC 上的信息
+#[napi]
+pub fn update_playback_rate(rate: f64) {
+    sys_media::get_platform_controls().update_playback_rate(rate);
+}
+
 /// 更新进度信息
 ///
 /// 同时也会更新 Discord 的进度信息 (如果启用了 Discord RPC)

--- a/native/external-media-integration/src/model.rs
+++ b/native/external-media-integration/src/model.rs
@@ -13,6 +13,7 @@ pub enum SystemMediaEventType {
     PreviousSong,
     ToggleShuffle,
     ToggleRepeat,
+    SetRate,
     /// 绝对位置，毫秒
     Seek,
 }
@@ -22,6 +23,7 @@ pub enum SystemMediaEventType {
 pub struct SystemMediaEvent {
     pub type_: SystemMediaEventType,
     pub position_ms: Option<f64>,
+    pub rate: Option<f64>,
 }
 
 impl SystemMediaEvent {
@@ -29,12 +31,21 @@ impl SystemMediaEvent {
         Self {
             type_: t,
             position_ms: None,
+            rate: None,
         }
     }
     pub const fn seek(pos: f64) -> Self {
         Self {
             type_: SystemMediaEventType::Seek,
             position_ms: Some(pos),
+            rate: None,
+        }
+    }
+    pub const fn set_rate(rate: f64) -> Self {
+        Self {
+            type_: SystemMediaEventType::SetRate,
+            position_ms: None,
+            rate: Some(rate),
         }
     }
 }

--- a/native/external-media-integration/src/sys_media/macos.rs
+++ b/native/external-media-integration/src/sys_media/macos.rs
@@ -11,13 +11,15 @@ use objc2::{
     runtime::{AnyObject, ProtocolObject},
 };
 use objc2_app_kit::NSImage;
-use objc2_foundation::{NSData, NSMutableDictionary, NSNumber, NSSize, NSString};
+use objc2_foundation::{NSArray, NSData, NSMutableDictionary, NSNumber, NSSize, NSString};
 use objc2_media_player::{
-    MPChangePlaybackPositionCommandEvent, MPChangeRepeatModeCommandEvent,
+    MPChangePlaybackPositionCommandEvent, MPChangePlaybackRateCommandEvent,
+    MPChangeRepeatModeCommandEvent,
     MPChangeShuffleModeCommandEvent, MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle,
     MPMediaItemPropertyArtist, MPMediaItemPropertyArtwork, MPMediaItemPropertyPersistentID,
     MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle, MPNowPlayingInfoCenter,
-    MPNowPlayingInfoPropertyElapsedPlaybackTime, MPNowPlayingPlaybackState, MPRemoteCommand,
+    MPNowPlayingInfoPropertyElapsedPlaybackTime, MPNowPlayingInfoPropertyPlaybackRate,
+    MPNowPlayingPlaybackState, MPRemoteCommand,
     MPRemoteCommandCenter, MPRemoteCommandEvent, MPRemoteCommandHandlerStatus, MPRepeatType,
     MPShuffleType,
 };
@@ -131,6 +133,54 @@ impl MacosImpl {
         }
     }
 
+    fn add_change_playback_rate_handler(&self) {
+        let command = unsafe { self.cmd_ctr.changePlaybackRateCommand() };
+        let handler_arc = self.event_handler.clone();
+
+        let block = RcBlock::new(
+            move |event: NonNull<MPRemoteCommandEvent>| -> MPRemoteCommandHandlerStatus {
+                let rate_evt_opt = unsafe { Retained::retain(event.as_ptr()) }
+                    .and_then(|evt| evt.downcast::<MPChangePlaybackRateCommandEvent>().ok());
+
+                if let Some(rate_evt) = rate_evt_opt {
+                    let rate = unsafe { rate_evt.playbackRate() };
+                    debug!(rate, "MPChangePlaybackRateCommand 触发");
+
+                    if let Ok(guard) = handler_arc.lock()
+                        && let Some(tsfn) = guard.as_ref()
+                    {
+                        let evt = SystemMediaEvent::set_rate(rate as f64);
+                        tsfn.call(
+                            evt,
+                            napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+                        );
+                    }
+                }
+
+                MPRemoteCommandHandlerStatus::Success
+            },
+        );
+
+        unsafe {
+            command.setEnabled(true);
+            // 这里可以设置 supportedPlaybackRates，但如果不设置，系统可能会提供默认选项或允许任意值
+            let rates = NSArray::from_retained_slice(&[
+                NSNumber::new_f64(0.25),
+                NSNumber::new_f64(0.5),
+                NSNumber::new_f64(0.75),
+                NSNumber::new_f64(1.0),
+                NSNumber::new_f64(1.25),
+                NSNumber::new_f64(1.5),
+                NSNumber::new_f64(1.75),
+                NSNumber::new_f64(2.0),
+            ]);
+            command.setSupportedPlaybackRates(&rates);
+
+            let token = command.addTargetWithHandler(&block);
+            self.store_token(&command, token);
+        }
+    }
+
     fn add_shuffle_handler(&self) {
         let command = unsafe { self.cmd_ctr.changeShuffleModeCommand() };
         let handler_arc = self.event_handler.clone();
@@ -204,6 +254,7 @@ impl MacosImpl {
             self.cmd_ctr
                 .changePlaybackPositionCommand()
                 .setEnabled(enabled);
+            self.cmd_ctr.changePlaybackRateCommand().setEnabled(enabled);
             self.cmd_ctr.changeShuffleModeCommand().setEnabled(enabled);
             self.cmd_ctr.changeRepeatModeCommand().setEnabled(enabled);
         }
@@ -235,6 +286,9 @@ impl MacosImpl {
 
         // Seek
         self.add_seek_handler();
+
+        // 速率
+        self.add_change_playback_rate_handler();
 
         // 随机和循环
         self.add_shuffle_handler();
@@ -401,6 +455,19 @@ impl SystemMediaControls for MacosImpl {
 
         unsafe {
             self.np_info_ctr.setPlaybackState(macos_state);
+        }
+    }
+
+    fn update_playback_rate(&self, rate: f64) {
+        if let Ok(mut info_guard) = self.info.lock() {
+            let info = &mut *info_guard;
+            unsafe {
+                info.setObject_forKey(
+                    &NSNumber::new_f64(rate),
+                    ProtocolObject::from_ref(MPNowPlayingInfoPropertyPlaybackRate),
+                );
+                self.np_info_ctr.setNowPlayingInfo(Some(info));
+            }
         }
     }
 

--- a/native/external-media-integration/src/sys_media/macos.rs
+++ b/native/external-media-integration/src/sys_media/macos.rs
@@ -14,12 +14,11 @@ use objc2_app_kit::NSImage;
 use objc2_foundation::{NSArray, NSData, NSMutableDictionary, NSNumber, NSSize, NSString};
 use objc2_media_player::{
     MPChangePlaybackPositionCommandEvent, MPChangePlaybackRateCommandEvent,
-    MPChangeRepeatModeCommandEvent,
-    MPChangeShuffleModeCommandEvent, MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle,
-    MPMediaItemPropertyArtist, MPMediaItemPropertyArtwork, MPMediaItemPropertyPersistentID,
-    MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle, MPNowPlayingInfoCenter,
-    MPNowPlayingInfoPropertyElapsedPlaybackTime, MPNowPlayingInfoPropertyPlaybackRate,
-    MPNowPlayingPlaybackState, MPRemoteCommand,
+    MPChangeRepeatModeCommandEvent, MPChangeShuffleModeCommandEvent, MPMediaItemArtwork,
+    MPMediaItemPropertyAlbumTitle, MPMediaItemPropertyArtist, MPMediaItemPropertyArtwork,
+    MPMediaItemPropertyPersistentID, MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle,
+    MPNowPlayingInfoCenter, MPNowPlayingInfoPropertyElapsedPlaybackTime,
+    MPNowPlayingInfoPropertyPlaybackRate, MPNowPlayingPlaybackState, MPRemoteCommand,
     MPRemoteCommandCenter, MPRemoteCommandEvent, MPRemoteCommandHandlerStatus, MPRepeatType,
     MPShuffleType,
 };
@@ -149,7 +148,7 @@ impl MacosImpl {
                     if let Ok(guard) = handler_arc.lock()
                         && let Some(tsfn) = guard.as_ref()
                     {
-                        let evt = SystemMediaEvent::set_rate(rate as f64);
+                        let evt = SystemMediaEvent::set_rate(f64::from(rate));
                         tsfn.call(
                             evt,
                             napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,

--- a/native/external-media-integration/src/sys_media/mod.rs
+++ b/native/external-media-integration/src/sys_media/mod.rs
@@ -46,6 +46,9 @@ pub trait SystemMediaControls: Send + Sync {
     /// 更新播放状态（播放/暂停）
     fn update_playback_status(&self, payload: PlayStatePayload);
 
+    /// 更新播放速率
+    fn update_playback_rate(&self, rate: f64);
+
     /// 更新进度条/时间轴
     ///
     /// `current` 和 `total` 单位均为毫秒。
@@ -112,6 +115,7 @@ impl SystemMediaControls for NoOpControls {
     }
     fn update_metadata(&self, _: MetadataPayload) {}
     fn update_playback_status(&self, _: PlayStatePayload) {}
+    fn update_playback_rate(&self, _: f64) {}
     fn update_timeline(&self, _: TimelinePayload) {}
     fn update_play_mode(&self, _: PlayModePayload) {}
 }

--- a/native/external-media-integration/src/sys_media/windows.rs
+++ b/native/external-media-integration/src/sys_media/windows.rs
@@ -240,6 +240,7 @@ impl SystemMediaControls for WindowsImpl {
                     debug!(rate, "SMTC 请求更改播放速率");
                     dispatch_event(SystemMediaEvent::set_rate(rate));
                 }
+                Ok(())
             },
         );
         let playback_rate_changed = smtc.PlaybackRateChanged(&playback_rate_handler)?;

--- a/native/external-media-integration/src/sys_media/windows.rs
+++ b/native/external-media-integration/src/sys_media/windows.rs
@@ -8,9 +8,9 @@ use windows::{
     Foundation::{TimeSpan, TypedEventHandler},
     Media::{
         MediaPlaybackAutoRepeatMode, MediaPlaybackStatus, MediaPlaybackType, Playback::MediaPlayer,
-        PlaybackPositionChangeRequestedEventArgs, SystemMediaTransportControls,
-        SystemMediaTransportControlsButton, SystemMediaTransportControlsButtonPressedEventArgs,
-        SystemMediaTransportControlsTimelineProperties,
+        PlaybackPositionChangeRequestedEventArgs, PlaybackRateChangeRequestedEvent,
+        SystemMediaTransportControls, SystemMediaTransportControlsButton,
+        SystemMediaTransportControlsButtonPressedEventArgs, SystemMediaTransportControlsTimelineProperties,
     },
     Storage::Streams::{DataWriter, InMemoryRandomAccessStream, RandomAccessStreamReference},
     core::{HSTRING, Ref},
@@ -34,6 +34,7 @@ struct SmtcHandlerTokens {
     shuffle_changed: i64,
     repeat_changed: i64,
     seek_requested: i64,
+    playback_rate_changed: i64,
 }
 
 struct SmtcContext {
@@ -55,6 +56,7 @@ impl SmtcContext {
         smtc.RemoveShuffleEnabledChangeRequested(self.tokens.shuffle_changed)?;
         smtc.RemoveAutoRepeatModeChangeRequested(self.tokens.repeat_changed)?;
         smtc.RemovePlaybackPositionChangeRequested(self.tokens.seek_requested)?;
+        smtc.RemovePlaybackRateChanged(self.tokens.playback_rate_changed)?;
         Ok(())
     }
 }
@@ -228,6 +230,20 @@ impl SystemMediaControls for WindowsImpl {
         );
         let seek_requested = smtc.PlaybackPositionChangeRequested(&seek_handler)?;
 
+        // 监听播放速率变化
+        let playback_rate_handler = TypedEventHandler::new(
+            move |_,
+                  args: Ref<PlaybackRateChangeRequestedEvent>|
+                  -> windows::core::Result<()> {
+                if let Some(args) = args.as_ref() {
+                    let rate = args.RequestedPlaybackRate()?;
+                    debug!(rate, "SMTC 请求更改播放速率");
+                    dispatch_event(SystemMediaEvent::set_rate(rate));
+                }
+            },
+        );
+        let playback_rate_changed = smtc.PlaybackRateChanged(&playback_rate_handler)?;
+
         debug!("SMTC 事件处理器已全部附加");
 
         let context = SmtcContext {
@@ -237,6 +253,7 @@ impl SystemMediaControls for WindowsImpl {
                 shuffle_changed,
                 repeat_changed,
                 seek_requested,
+                playback_rate_changed,
             },
             callback: None,
             cover_task: None,
@@ -389,7 +406,22 @@ impl SystemMediaControls for WindowsImpl {
     }
 
     fn update_playback_rate(&self, rate: f64) {
-        // 未实现
+        debug!(rate, "正在更新 SMTC 播放速率");
+
+        TOKIO_RUNTIME.spawn(async move {
+            let result = with_smtc_ctx("更新播放速率", |ctx| {
+                if !ctx.is_enabled {
+                    return Ok(());
+                }
+                let smtc = ctx.smtc()?;
+                smtc.SetPlaybackRate(rate)?;
+                debug!("更新 SMTC 播放速率成功: {}", rate);
+                Ok(())
+            });
+            if let Err(e) = result {
+                error!("更新播放速率失败: {e:?}");
+            }
+        });
     }
 
     fn update_timeline(&self, payload: TimelinePayload) {

--- a/native/external-media-integration/src/sys_media/windows.rs
+++ b/native/external-media-integration/src/sys_media/windows.rs
@@ -8,9 +8,10 @@ use windows::{
     Foundation::{TimeSpan, TypedEventHandler},
     Media::{
         MediaPlaybackAutoRepeatMode, MediaPlaybackStatus, MediaPlaybackType, Playback::MediaPlayer,
-        PlaybackPositionChangeRequestedEventArgs, PlaybackRateChangeRequestedEvent,
+        PlaybackPositionChangeRequestedEventArgs, PlaybackRateChangeRequestedEventArgs,
         SystemMediaTransportControls, SystemMediaTransportControlsButton,
-        SystemMediaTransportControlsButtonPressedEventArgs, SystemMediaTransportControlsTimelineProperties,
+        SystemMediaTransportControlsButtonPressedEventArgs,
+        SystemMediaTransportControlsTimelineProperties,
     },
     Storage::Streams::{DataWriter, InMemoryRandomAccessStream, RandomAccessStreamReference},
     core::{HSTRING, Ref},
@@ -56,7 +57,7 @@ impl SmtcContext {
         smtc.RemoveShuffleEnabledChangeRequested(self.tokens.shuffle_changed)?;
         smtc.RemoveAutoRepeatModeChangeRequested(self.tokens.repeat_changed)?;
         smtc.RemovePlaybackPositionChangeRequested(self.tokens.seek_requested)?;
-        smtc.RemovePlaybackRateChanged(self.tokens.playback_rate_changed)?;
+        smtc.RemovePlaybackRateChangeRequested(self.tokens.playback_rate_changed)?;
         Ok(())
     }
 }
@@ -153,6 +154,7 @@ impl WindowsImpl {
 
 impl SystemMediaControls for WindowsImpl {
     #[instrument]
+    #[allow(clippy::too_many_lines)] // TODO: 重构以解决此警告
     fn initialize(&self) -> Result<()> {
         info!("正在初始化 SMTC...");
 
@@ -233,7 +235,7 @@ impl SystemMediaControls for WindowsImpl {
         // 监听播放速率变化
         let playback_rate_handler = TypedEventHandler::new(
             move |_,
-                  args: Ref<PlaybackRateChangeRequestedEvent>|
+                  args: Ref<PlaybackRateChangeRequestedEventArgs>|
                   -> windows::core::Result<()> {
                 if let Some(args) = args.as_ref() {
                     let rate = args.RequestedPlaybackRate()?;
@@ -243,7 +245,7 @@ impl SystemMediaControls for WindowsImpl {
                 Ok(())
             },
         );
-        let playback_rate_changed = smtc.PlaybackRateChanged(&playback_rate_handler)?;
+        let playback_rate_changed = smtc.PlaybackRateChangeRequested(&playback_rate_handler)?;
 
         debug!("SMTC 事件处理器已全部附加");
 

--- a/native/external-media-integration/src/sys_media/windows.rs
+++ b/native/external-media-integration/src/sys_media/windows.rs
@@ -388,6 +388,10 @@ impl SystemMediaControls for WindowsImpl {
         });
     }
 
+    fn update_playback_rate(&self, rate: f64) {
+        // 未实现
+    }
+
     fn update_timeline(&self, payload: TimelinePayload) {
         // trace!(current_time, total_time, "正在更新 SMTC 时间线");
 

--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -2,7 +2,7 @@ import { useMusicStore, useSettingStore, useStatusStore } from "@/stores";
 import { isElectron } from "@/utils/env";
 import { getPlaySongData } from "@/utils/format";
 import { msToS } from "@/utils/time";
-import { SystemMediaEvent } from "@emi";
+import type { SystemMediaEvent } from "@emi";
 import axios from "axios";
 import { throttle } from "lodash-es";
 import { usePlayerController } from "./PlayerController";
@@ -23,6 +23,7 @@ import {
  */
 class MediaSessionManager {
   private metadataAbortController: AbortController | null = null;
+  private currentRate: number = 1;
 
   private throttledSendTimeline = throttle((currentTime: number, duration: number) => {
     sendMediaTimeline(currentTime, duration);
@@ -89,6 +90,8 @@ class MediaSessionManager {
 
     const player = usePlayerController();
     const statusStore = useStatusStore();
+
+    this.currentRate = statusStore.playRate;
 
     if (isElectron) {
       window.electron.ipcRenderer.removeAllListeners("media-event");
@@ -318,6 +321,8 @@ class MediaSessionManager {
    * 更新播放速率
    */
   public updatePlaybackRate(rate: number) {
+    this.currentRate = rate;
+
     if (this.shouldUseNativeMedia()) {
       sendMediaPlaybackRate(rate);
     }
@@ -331,6 +336,7 @@ class MediaSessionManager {
       navigator.mediaSession.setPositionState({
         duration: msToS(duration),
         position: msToS(position),
+        playbackRate: this.currentRate,
       });
     }
   }, 1000);

--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -9,6 +9,7 @@ import { usePlayerController } from "./PlayerController";
 import {
   enableDiscordRpc,
   sendMediaMetadata,
+  sendMediaPlaybackRate,
   sendMediaPlayMode,
   sendMediaPlayState,
   sendMediaTimeline,
@@ -71,6 +72,11 @@ class MediaSessionManager {
       case "ToggleRepeat":
         player.toggleRepeat();
         break;
+      case "SetRate":
+        if (event.rate != null) {
+          player.setRate(event.rate);
+        }
+        break;
     }
   }
 
@@ -101,6 +107,9 @@ class MediaSessionManager {
       sendMediaPlayMode(shuffle, repeat);
 
       player.syncMediaPlayMode();
+
+      // 同步初始播放速率
+      sendMediaPlaybackRate(statusStore.playRate);
 
       // Discord RPC 初始化
       if (settingStore.discordRpc.enabled) {
@@ -302,6 +311,15 @@ class MediaSessionManager {
     // 发送到原生插件
     if (this.shouldUseNativeMedia()) {
       sendMediaPlayState(isPlaying ? "Playing" : "Paused");
+    }
+  }
+
+  /**
+   * 更新播放速率
+   */
+  public updatePlaybackRate(rate: number) {
+    if (this.shouldUseNativeMedia()) {
+      sendMediaPlaybackRate(rate);
     }
   }
 

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -932,19 +932,29 @@ class PlayerController {
 
   /**
    * 设置播放速率
-   * @param rate 速率 (0.25 - 2.0)
+   * @param rate 速率 (0.2 - 2.0)
    */
   public setRate(rate: number) {
     const statusStore = useStatusStore();
     const audioManager = useAudioManager();
 
-    statusStore.playRate = rate;
+    if (!Number.isFinite(rate)) {
+      console.warn("⚠️ 无效的播放速率:", rate);
+      return;
+    }
+    if (audioManager.engineType === "mpv") {
+      console.warn("⚠️ MPV 引擎不支持倍速播放");
+      return;
+    }
+    const safeRate = Math.max(0.2, Math.min(rate, 2.0));
+
+    statusStore.playRate = safeRate;
 
     // 统一调用 audioManager
-    audioManager.setRate(rate);
+    audioManager.setRate(safeRate);
 
     // 更新系统播放速率
-    mediaSessionManager.updatePlaybackRate(rate);
+    mediaSessionManager.updatePlaybackRate(safeRate);
   }
 
   /**

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -942,6 +942,9 @@ class PlayerController {
 
     // 统一调用 audioManager
     audioManager.setRate(rate);
+
+    // 更新系统播放速率
+    mediaSessionManager.updatePlaybackRate(rate);
   }
 
   /**

--- a/src/core/player/PlayerIpc.ts
+++ b/src/core/player/PlayerIpc.ts
@@ -204,7 +204,7 @@ export const sendMediaPlayState = (status: PlaybackStatus) => {
 /**
  * @description 通过外部媒体集成模块更新媒体控件的播放速率
  * @note 仅在 Electron 上有效
- * @param rate - 播放速率 (默认 1.0)
+ * @param rate - 播放速率，1.0 表示正常速度
  * @see {@link EmiModule.updatePlaybackRate 外部媒体集成模块的 `updatePlaybackRate` 方法}
  */
 export const sendMediaPlaybackRate = (rate: number) => {

--- a/src/core/player/PlayerIpc.ts
+++ b/src/core/player/PlayerIpc.ts
@@ -202,6 +202,16 @@ export const sendMediaPlayState = (status: PlaybackStatus) => {
 };
 
 /**
+ * @description 通过外部媒体集成模块更新媒体控件的播放速率
+ * @note 仅在 Electron 上有效
+ * @param rate - 播放速率 (默认 1.0)
+ * @see {@link EmiModule.updatePlaybackRate 外部媒体集成模块的 `updatePlaybackRate` 方法}
+ */
+export const sendMediaPlaybackRate = (rate: number) => {
+  if (isElectron) window.electron.ipcRenderer.send("media-update-playback-rate", { rate });
+};
+
+/**
  * @description 通过外部媒体集成模块更新媒体控件和 Discord RPC 的播放状态
  * @note 仅在 Electron 上有效
  * @param currentTime - 当前的播放进度，单位是毫秒


### PR DESCRIPTION
现在可以在 EMI 中读写 SPlayer 的播放速率

## 变更

### 通用

- 在 `SystemMediaControls` 下新增 `update_playback_rate` 函数
- 会在 `PlayerController` 的 `setRate` 中通过 Ipc 调用 `updatePlaybackRate` 更新播放速率
- 在 `SystemMediaEventType` 中新增 `SetRate` 事件类型，并在 `SystemMediaEvent` 中添加了 `rate` 字段
- 在 `MediaSessionManager` 中监听了 `SetRate` 事件，并调用 `PlayerController` 中的 `setRate`

### Linux 实现

- 通过 `mpris-server` 的 `set_rate` 和 `connect_set_rate` 来设置和监听 MPRIS 的 `Rate` 属性
- 设置了 `MinimumRate` 和 `MaximumRate`

### macOS 实现

AI 写的，我也不知道（

参考：
 - [MPNowPlayingInfoPropertyPlaybackRate | Apple Developer Documentation](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfopropertyplaybackrate)
 - [MPChangePlaybackRateCommandEvent | Apple Developer Documentation](https://developer.apple.com/documentation/mediaplayer/mpchangeplaybackratecommandevent)
 - [objc2_media_player - Rust](https://docs.rs/objc2-media-player/latest/objc2_media_player/)

## 备注

此提交为 AI 生成后人工更正，Linux 实现在 KDE 下测试正常工作，macOS 实现也会找人测的

已在 [此处](https://github.com/MoYingJi/SPlayer/actions/runs/21892291325) 执行 GitHub Actions，可以下载测试

~~未产生实际变更的自动生成代码均未包含在本提交中，`native/external-media-integration/index.d.ts` 产生了实际变更，在提交前已格式化以匹配仓库中的文件~~（现在自动格式化排除了这些自动生成文件）