### PR TITLE
fix: 扫描本地音乐时漏掉 opus 后缀音频

### DIFF
--- a/electron/main/services/MusicMetadataService.ts
+++ b/electron/main/services/MusicMetadataService.ts
@@ -28,7 +28,7 @@ export interface MusicMetadataInput {
 }
 
 /** 支持的音乐文件扩展名列表 */
-const MUSIC_EXTENSIONS = ["mp3", "wav", "flac", "aac", "webm", "m4a", "ogg", "aiff", "aif", "aifc"];
+const MUSIC_EXTENSIONS = ["mp3", "wav", "flac", "aac", "webm", "m4a", "ogg", "aiff", "aif", "aifc", "opus"];
 
 /**
  * 获取全局搜索配置


### PR DESCRIPTION
在支持的后缀列表中追加了 `, "opus"` ，且经测试（GNU/Linux）其可以正常解析opus格式的元数据。

相关 issue：#879