### PR TITLE
feat(SearchInp): 支持搜索词同步

### DIFF
--- a/src/components/Setting/config/general.ts
+++ b/src/components/Setting/config/general.ts
@@ -325,13 +325,18 @@ export const useGeneralSettings = (): SettingConfig => {
             }),
           },
           {
-            key: "clearSearchOnBlur",
-            label: "失焦自动清空搜索框",
-            type: "switch",
-            description: "搜索框失去焦点后自动清空内容",
+            key: "searchInputBehavior",
+            label: "搜索框行为",
+            type: "select",
+            description: "自定义搜索框的行为模式",
+            options: [
+              { label: "保留搜索词", value: "normal" },
+              { label: "失焦后清空", value: "clear" },
+              { label: "同步搜索词", value: "sync" },
+            ],
             value: computed({
-              get: () => settingStore.clearSearchOnBlur,
-              set: (v) => (settingStore.clearSearchOnBlur = v),
+              get: () => settingStore.searchInputBehavior,
+              set: (v) => (settingStore.searchInputBehavior = v),
             }),
           },
           {

--- a/src/stores/migrations/settingMigrations.ts
+++ b/src/stores/migrations/settingMigrations.ts
@@ -6,7 +6,7 @@ import type { SettingState } from "../setting";
 /**
  * 当前设置 Schema 版本号
  */
-export const CURRENT_SETTING_SCHEMA_VERSION = 9;
+export const CURRENT_SETTING_SCHEMA_VERSION = 10;
 
 /**
  * 迁移函数类型
@@ -178,5 +178,12 @@ export const settingMigrations: Record<number, MigrationFunction> = {
       enableQQMusicLyric: preferQM,
       lyricPriority: preferQM ? "qm" : "auto",
     };
+  },
+  10: (state) => {
+    interface OldSettingState extends Partial<SettingState> {
+      clearSearchOnBlur?: boolean;
+    }
+    const oldState = state as OldSettingState;
+    return oldState.clearSearchOnBlur === true ? { searchInputBehavior: "clear" } : {};
   },
 };

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -413,8 +413,8 @@ export interface SettingState {
   };
   /** 启用搜索关键词获取 */
   enableSearchKeyword: boolean;
-  /** 失焦后自动清空搜索框 */
-  clearSearchOnBlur: boolean;
+  /** 搜索框行为 */
+  searchInputBehavior: "normal" | "clear" | "sync";
   /** 显示主页问好 */
   showHomeGreeting: boolean;
   /** 首页栏目顺序和显示配置 */
@@ -703,7 +703,7 @@ export const useSettingStore = defineStore("setting", {
       musicTagEditor: true,
     },
     enableSearchKeyword: true,
-    clearSearchOnBlur: false,
+    searchInputBehavior: "normal",
     showHomeGreeting: true,
     homePageSections: [
       { key: "playlist", name: "专属歌单", visible: true, order: 0 },


### PR DESCRIPTION
将 `clearSearchOnBlur` 设置项扩充为 `searchInputBehavior`，保留原有的 `normal` 和 `clear` 模式，增加了 `sync` 模式（如果当前是搜索页，则同步搜索页的搜索词到搜索框，如果是其他页面，则清空搜索框）