### PR TITLE
🦄refactor(mac/tray/lyric): 重构 macOS 状态栏歌词功能，解决多项显示与交互问题，全面提升稳定性与用户体验

### DIFF
--- a/electron/main/ipc/ipc-mac-statusbar.ts
+++ b/electron/main/ipc/ipc-mac-statusbar.ts
@@ -123,8 +123,7 @@ export const initMacStatusBarIpc = () => {
   
   // 根据初始设置状态更新托盘显示
   // 如果禁用，设置回歌曲标题
-  if (isMacosLyricEnabled) {
-  } else {
+  if (!isMacosLyricEnabled) {
     tray?.setTitle(getCurrentSongTitle());
   }
 
@@ -135,7 +134,7 @@ export const initMacStatusBarIpc = () => {
     const mainWin = mainWindow.getWin();
 
     // 强制更新托盘菜单，以响应新的开启/关闭状态
-    (tray as any)?.initTrayMenu();
+    tray?.initTrayMenu();
 
     if (mainWin && !mainWin.isDestroyed()) {
       // 发送更新给渲染进程，同步 Pinia store

--- a/electron/main/tray/index.ts
+++ b/electron/main/tray/index.ts
@@ -103,7 +103,8 @@ const getMenuIcon = (iconName: string): NativeImage | undefined => {
 };
 
 // 托盘菜单
-const createTrayMenu = (win: BrowserWindow, store: ReturnType<typeof useStore>): MenuItemConstructorOptions[] => {
+const createTrayMenu = (win: BrowserWindow): MenuItemConstructorOptions[] => {
+  const store = useStore();
   /**
    * 获取 {@linkcode RepeatModeType} 对应的显示字符串
    * @param mode 重复模式
@@ -267,11 +268,9 @@ class CreateTray implements MainTray {
   // 菜单
   private _menu: MenuItemConstructorOptions[];
   private _contextMenu: Menu;
-  private _store: ReturnType<typeof useStore>; // 添加 store 成员变量以访问全局状态
 
   constructor(win: BrowserWindow) {
     this._win = win;
-    this._store = useStore();
 
     if (isWin) {
       const iconPath = join(__dirname, `../../public/icons/tray/tray.ico`);
@@ -290,7 +289,7 @@ class CreateTray implements MainTray {
       this._tray = new Tray(icon);
     }
 
-    this._menu = createTrayMenu(this._win, this._store);
+    this._menu = createTrayMenu(this._win);
     this._contextMenu = Menu.buildFromTemplate(this._menu);
     this.initTrayMenu();
     this.initEvents();
@@ -298,7 +297,7 @@ class CreateTray implements MainTray {
   }
   // 托盘菜单
   public initTrayMenu() {
-    this._menu = createTrayMenu(this._win, this._store);
+    this._menu = createTrayMenu(this._win);
     this._contextMenu = Menu.buildFromTemplate(this._menu);
     this._tray.setContextMenu(this._contextMenu);
   }


### PR DESCRIPTION
本次提交对 macOS 状态栏歌词功能进行了深度优化与结构性重构，旨在全面提升其稳定性、响应速度、用户体验及代码可维护性，修复了系列显示与交互问题：

**核心重构与优化：**

- **统一状态管理，消除功能切换的竞态条件**：
  * 通过 `store.get("macos.statusBarLyric.enabled")` 直接在关键逻辑点查询最新状态。
  * 将 macOS 状态栏歌词的启用状态集中至全局 `Store` 管理，取代了此前分散且易导致不一致的局部变量。
  * 此举显著增强了状态管理的一致性与可控性，从根本上解决了功能开启/关闭逻辑中因状态不同步导致的竞态条件和行为异常。

- **明确模块职责边界，消除 UI 渲染冲突**：
  * 移除 `electron/main/tray/index.ts` 中冗余的 `setMacStatusBarLyricShow` 和 `setMacStatusBarLyricTitle` 方法，并通过 `ipc-tray.ts` 导出 `getCurrentSongTitle`。
  * 使 `ipc-mac-statusbar.ts` 在歌词功能关闭时**直接调用 `tray?.setTitle(getCurrentSongTitle())`**。
  * 精简了托盘（Tray）模块对状态栏标题的控制逻辑，赋予 macOS 歌词功能模块在激活时对状态栏标题的权威控制权。这彻底解决了歌词与歌曲信息相互覆盖、导致启动时显示歌曲名或拖动时闪烁的 UI 渲染冲突。
  
- **增强歌词显示与更新机制，优化平滑度与精确性**：
  * 在 `updateMacStatusBarLyric` 函数中添加 `forceUpdate` 参数和 `isMacosLyricEnabled` 检查，并将歌词更新的权威触发点统一到 `TASKBAR_IPC_CHANNELS.SYNC_TICK` 事件处理器。
  * 引入 `updateMacStatusBarLyric` 的 `forceUpdate` 参数，并优化了歌词在启动和进度拖动时的更新策略。
  * 此机制确保歌词显示更为平滑、精确，解决了歌词在启动时延迟显示或拖动歌曲进度时跳动、闪烁的问题，显著提升了视觉流畅度。

- **改进托盘菜单 UI 同步，提升交互一致性**：
  * 通过在 `macos-lyric:toggle` 事件处理器中**调用 `(tray as any)?.initTrayMenu()`** 来强制刷新托盘菜单，并修改 `createTrayMenu` 直接从 `Store` 读取状态。
  * 实现了托盘菜单项（“开启/关闭状态栏歌词”）与实际歌词功能启用状态的实时同步。解决了菜单标签未能及时反映真实状态的 UI bug，提升了用户交互的直观性与一致性。

- **提升代码健壮性与可维护性**：
  * 在 `MainTray` 接口中添加 `initTrayMenu(): void` 声明；将 `CreateTray` 类中的 `initTrayMenu` 方法改为 `public`。
  * 移除 `electron/main/index.ts` 中不再使用的 `ipcMain` 和 `useStore` 导入。
  * 统一 `electron/main/ipc/ipc-mac-statusbar.ts` 中的歌词和 IPC payload 类型，使其与 `@applemusic-like-lyrics/lyric` 和 `@shared` 模块保持一致。
  * 优化了类型接口与实现，移除了冗余代码及不再需要的导入，使整体代码结构更加清晰，降低了长期维护成本，为未来的功能扩展奠定了坚实基础。
  
本次重构全面提升了 macOS 状态栏歌词功能的内部机制，带来了更稳定、更流畅、更符合预期的用户体验。