### PR TITLE
🐞fix(player/automix): 修复自动混音过渡时桌面歌词与 macOS 状态栏信息不更新的问题

### DIFF
--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -572,13 +572,28 @@ class PlayerController {
     }
     // 更新任务栏歌词窗口的元数据
     // 注意：getPlayerInfoObj 内部读取 musicStore.playSong，所以上面必须先赋值
-    const { name, artist } = getPlayerInfoObj() || {};
+    const { name, artist, album } = getPlayerInfoObj() || {};
     const coverUrl = song.coverSize?.s || song.cover || "";
     playerIpc.sendTaskbarMetadata({
       title: name || "",
       artist: artist || "",
       cover: coverUrl,
     });
+
+    // 主动通知桌面歌词和 macOS 状态栏歌词 确保 AutoMix 平滑过渡时也触发更新
+    if (isElectron) {
+      const playTitle = `${name} - ${artist}`;
+      playerIpc.sendSongChange(playTitle, name || "", artist || "", album || "");
+
+      if (isMac) {
+        window.electron.ipcRenderer.send("mac-statusbar:update-progress", {
+          currentTime: startSeek,
+          duration: song.duration,
+          offset: statusStore.getSongOffset(song.id),
+        });
+      }
+    }
+
     // 获取歌词
     lyricManager.handleLyric(song);
     console.log(`🎧 [${song.id}] 最终播放信息:`, audioSource);

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -586,7 +586,7 @@ class PlayerController {
       playerIpc.sendSongChange(playTitle, name || "", artist || "", album || "");
 
       if (isMac) {
-        window.electron.ipcRenderer.send("mac-statusbar:update-progress", {
+        playerIpc.sendTaskbarProgressData({
           currentTime: startSeek,
           duration: song.duration,
           offset: statusStore.getSongOffset(song.id),


### PR DESCRIPTION
- 在 setupSongUI 函数中增加显式的元数据通知逻辑，确保所有平台歌词组件信息同步：
  - 调用 playerIpc.sendSongChange 主动通知桌面歌词更新歌曲名称与艺术家。
  - 在 macOS 平台发送 mac-statusbar:update-progress 消息，初始化状态栏进度与显示。
- 解决平滑过渡模式下的数据竞态：
  - 修复 AutoMix 模式下底层音频加载先于 UI 切换，导致 canplay 事件触发时 musicStore.playSong 尚未更新的问题。
  - 通过在 UI 实际切换点再次主动推送元数据，覆盖之前由于竞态发送的旧歌信息，确保歌词组件信息准确。