### PR TITLE
feat(EMI): 添加音量控制功能 (linux-only)

### DIFF
--- a/electron/main/ipc/ipc-media.ts
+++ b/electron/main/ipc/ipc-media.ts
@@ -87,6 +87,16 @@ const initMediaIpc = () => {
     }
   });
 
+  // 音量更新
+  ipcMain.on("media-update-volume", (_, payload: { volume: number }) => {
+    if (!emi) return;
+    try {
+      emi.updateVolume(payload.volume);
+    } catch (e) {
+      processLog.error("[Media] 更新音量失败", e);
+    }
+  });
+
   // 进度更新
   ipcMain.on("media-update-timeline", (_, payload: TimelinePayload) => {
     if (!emi) return;

--- a/native/external-media-integration/index.d.ts
+++ b/native/external-media-integration/index.d.ts
@@ -137,6 +137,7 @@ export interface SystemMediaEvent {
   type: SystemMediaEventType
   positionMs?: number
   rate?: number
+  volume?: number
 }
 
 export type SystemMediaEventType =  'Play'|
@@ -147,6 +148,7 @@ export type SystemMediaEventType =  'Play'|
 'ToggleShuffle'|
 'ToggleRepeat'|
 'SetRate'|
+'SetVolume'|
 /** 绝对位置，毫秒 */
 'Seek';
 
@@ -213,3 +215,12 @@ export declare function updatePlayState(payload: PlayStatePayload): void
  * Discord RPC 实现的进度更新有节流，调用此函数无需担心 Discord RPC 的速率限制
  */
 export declare function updateTimeline(payload: TimelinePayload): void
+
+/**
+ * 更新音量
+ *
+ * ### 备注
+ *
+ * 只会更新媒体控件的信息，不会更新 Discord RPC 上的信息
+ */
+export declare function updateVolume(volume: number): void

--- a/native/external-media-integration/src/lib.rs
+++ b/native/external-media-integration/src/lib.rs
@@ -137,6 +137,16 @@ pub fn update_playback_rate(rate: f64) {
     sys_media::get_platform_controls().update_playback_rate(rate);
 }
 
+/// 更新音量
+///
+/// ### 备注
+///
+/// 只会更新媒体控件的信息，不会更新 Discord RPC 上的信息
+#[napi]
+pub fn update_volume(volume: f64) {
+    sys_media::get_platform_controls().update_volume(volume);
+}
+
 /// 更新进度信息
 ///
 /// 同时也会更新 Discord 的进度信息 (如果启用了 Discord RPC)

--- a/native/external-media-integration/src/model.rs
+++ b/native/external-media-integration/src/model.rs
@@ -14,6 +14,7 @@ pub enum SystemMediaEventType {
     ToggleShuffle,
     ToggleRepeat,
     SetRate,
+    SetVolume,
     /// 绝对位置，毫秒
     Seek,
 }
@@ -24,6 +25,7 @@ pub struct SystemMediaEvent {
     pub type_: SystemMediaEventType,
     pub position_ms: Option<f64>,
     pub rate: Option<f64>,
+    pub volume: Option<f64>,
 }
 
 impl SystemMediaEvent {
@@ -32,6 +34,7 @@ impl SystemMediaEvent {
             type_: t,
             position_ms: None,
             rate: None,
+            volume: None,
         }
     }
     pub const fn seek(pos: f64) -> Self {
@@ -39,6 +42,7 @@ impl SystemMediaEvent {
             type_: SystemMediaEventType::Seek,
             position_ms: Some(pos),
             rate: None,
+            volume: None,
         }
     }
     pub const fn set_rate(rate: f64) -> Self {
@@ -46,6 +50,15 @@ impl SystemMediaEvent {
             type_: SystemMediaEventType::SetRate,
             position_ms: None,
             rate: Some(rate),
+            volume: None,
+        }
+    }
+    pub const fn set_volume(volume: f64) -> Self {
+        Self {
+            type_: SystemMediaEventType::SetVolume,
+            position_ms: None,
+            rate: None,
+            volume: Some(volume),
         }
     }
 }

--- a/native/external-media-integration/src/sys_media/linux.rs
+++ b/native/external-media-integration/src/sys_media/linux.rs
@@ -32,6 +32,7 @@ pub enum MprisCommand {
     UpdateMetadata(MetadataPayload),
     UpdatePlaybackStatus(PlayStatePayload),
     UpdatePlaybackRate(f64),
+    UpdateVolume(f64),
     UpdateTimeline(TimelinePayload),
     UpdatePlayMode(PlayModePayload),
     Enable,
@@ -151,6 +152,13 @@ fn setup_mpris_signals(
     player.connect_set_rate(move |_, new_rate| {
         debug!(?new_rate, "收到 set_rate 命令");
         d(SystemMediaEvent::set_rate(new_rate));
+    });
+
+    // 音量
+    let d = dispatch.clone();
+    player.connect_set_volume(move |_, new_volume| {
+        debug!(?new_volume, "收到 set_volume 命令");
+        d(SystemMediaEvent::set_volume(new_volume));
     });
 
     // 相对跳转
@@ -277,6 +285,10 @@ async fn handle_command(
             player.set_rate(rate).await.ok();
         }
 
+        MprisCommand::UpdateVolume(volume) => {
+            player.set_volume(volume).await.ok();
+        }
+
         MprisCommand::UpdateTimeline(payload) => {
             let pos = Time::from_millis(payload.current_time as i64);
             player.set_position(pos);
@@ -401,6 +413,10 @@ impl SystemMediaControls for LinuxImpl {
 
     fn update_playback_rate(&self, rate: f64) {
         self.send_command(MprisCommand::UpdatePlaybackRate(rate));
+    }
+
+    fn update_volume(&self, volume: f64) {
+        self.send_command(MprisCommand::UpdateVolume(volume));
     }
 
     fn update_timeline(&self, payload: TimelinePayload) {

--- a/native/external-media-integration/src/sys_media/macos.rs
+++ b/native/external-media-integration/src/sys_media/macos.rs
@@ -507,6 +507,10 @@ impl SystemMediaControls for MacosImpl {
         }
     }
 
+    fn update_volume(&self, _volume: f64) {
+        // 未实现
+    }
+
     fn update_timeline(&self, payload: TimelinePayload) {
         let current_secs = payload.current_time / 1000.0;
         let total_secs = payload.total_time / 1000.0;

--- a/native/external-media-integration/src/sys_media/mod.rs
+++ b/native/external-media-integration/src/sys_media/mod.rs
@@ -48,6 +48,9 @@ pub trait SystemMediaControls: Send + Sync {
 
     /// 更新播放速率
     fn update_playback_rate(&self, rate: f64);
+    
+    /// 更新音量
+    fn update_volume(&self, volume: f64);
 
     /// 更新进度条/时间轴
     ///
@@ -116,6 +119,7 @@ impl SystemMediaControls for NoOpControls {
     fn update_metadata(&self, _: MetadataPayload) {}
     fn update_playback_status(&self, _: PlayStatePayload) {}
     fn update_playback_rate(&self, _: f64) {}
+    fn update_volume(&self, _: f64) {}
     fn update_timeline(&self, _: TimelinePayload) {}
     fn update_play_mode(&self, _: PlayModePayload) {}
 }

--- a/native/external-media-integration/src/sys_media/windows.rs
+++ b/native/external-media-integration/src/sys_media/windows.rs
@@ -427,6 +427,10 @@ impl SystemMediaControls for WindowsImpl {
         });
     }
 
+    fn update_volume(&self, _volume: f64) {
+        // 未实现
+    }
+
     fn update_timeline(&self, payload: TimelinePayload) {
         // trace!(current_time, total_time, "正在更新 SMTC 时间线");
 

--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -9,9 +9,10 @@ import { usePlayerController } from "./PlayerController";
 import {
   enableDiscordRpc,
   sendMediaMetadata,
-  sendMediaPlaybackRate,
   sendMediaPlayMode,
   sendMediaPlayState,
+  sendMediaPlaybackRate,
+  sendMediaVolume,
   sendMediaTimeline,
   updateDiscordConfig,
 } from "./PlayerIpc";
@@ -76,6 +77,11 @@ class MediaSessionManager {
       case "SetRate":
         if (event.rate != null) {
           player.setRate(event.rate);
+        }
+        break;
+      case "SetVolume":
+        if (event.volume != null) {
+          player.setVolume(event.volume);
         }
         break;
     }
@@ -325,6 +331,12 @@ class MediaSessionManager {
 
     if (this.shouldUseNativeMedia()) {
       sendMediaPlaybackRate(rate);
+    }
+  }
+
+  public updateVolume(volume: number) {
+    if (this.shouldUseNativeMedia()) {
+      sendMediaVolume(volume);
     }
   }
 

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -2266,6 +2266,9 @@ class PlayerController {
 
     // 统一调用 audioManager
     audioManager.setVolume(statusStore.playVolume);
+
+    // 更新系统集成音量
+    mediaSessionManager.updateVolume(statusStore.playVolume);
   }
 
   /** 切换静音 */

--- a/src/core/player/PlayerIpc.ts
+++ b/src/core/player/PlayerIpc.ts
@@ -236,6 +236,16 @@ export const sendMediaPlaybackRate = (rate: number) => {
 };
 
 /**
+ * @description 通过外部媒体集成模块更新媒体控件的音量
+ * @note 仅在 Electron 上有效
+ * @param volume - 音量，范围是 0.0（静音）到 1.0（最大音量）
+ * @see {@link EmiModule.updateVolume 外部媒体集成模块的 `updateVolume` 方法}
+ */
+export const sendMediaVolume = (volume: number) => {
+  if (isElectron) window.electron.ipcRenderer.send("media-update-volume", { volume });
+};
+
+/**
  * @description 通过外部媒体集成模块更新媒体控件和 Discord RPC 的播放状态
  * @note 仅在 Electron 上有效
  * @param currentTime - 当前的播放进度，单位是毫秒


### PR DESCRIPTION
实现了 `volume` 的双向通道，在 `PlayerController` 中的 `setVolume` 中更新 EMI，监听 EMI 调用 `setVolume`

macOS 没有实现，因为在 [Apple Developer Documentation](https://developer.apple.com/documentation/mediaplayer/mpmusicplayercontroller/volume) 中被标记为 Deprecated

在 Linux (mpris-ctl) 上测试通过

~~Windows 实现为 AI 生成，通过编译 ([workflow](https://github.com/MoYingJi/SPlayer/actions/runs/22222686005))~~ （Windows 没有）