### PR TITLE
🐞 fix: 修复解析QRC时丢失左括号的bug

### DIFF
--- a/src/utils/lyric/lyricParser.ts
+++ b/src/utils/lyric/lyricParser.ts
@@ -1,7 +1,7 @@
-import { cloneDeep } from "lodash-es";
 import type { LyricLine } from "@applemusic-like-lyrics/lyric";
-import { extractLyricContent } from "./qrc-parser";
+import { cloneDeep } from "lodash-es";
 import { parseLrc } from "./parseLrc";
+import { extractLyricContent } from "./qrc-parser";
 
 /**
  * LRC 格式类型
@@ -27,7 +27,7 @@ const LINE_TIME_REGEX = /^\[(\d{2}):(\d{2})\.(\d{1,})\]/;
 
 // QRC 解析相关正则 - 提前编译
 const QRC_LINE_PATTERN = /^\[(\d+),(\d+)\](.*)$/;
-const QRC_WORD_PATTERN = /([^(]*)\((\d+),(\d+)\)/g;
+const QRC_WORD_PATTERN = /(.*?)\((\d+),(\d+)\)/g;
 
 const DEFAULT_WORD_DURATION = 1000;
 const ALIGN_TOLERANCE_MS = 300;


### PR DESCRIPTION
修复了一个解析 QRC 歌词文件时左括号意外丢失的 bug

例如有歌词行为

`[0,21260]Mine(0,1417) (1417,1417)((2834,1417)Illenium(4251,1417) (5668,1417)Remix(7085,1417))(8502,1417)`

现在可以正确解析出 `((2834,1417)` 的左括号而不会丢失了