### PR TITLE
feat(歌词): 新增屏蔽词还原功能

### DIFF
--- a/src/components/Setting/config/play.ts
+++ b/src/components/Setting/config/play.ts
@@ -511,6 +511,16 @@ export const usePlaySettings = (): SettingConfig => {
             }),
           },
           {
+            key: "uncensorMaskedProfanity",
+            label: "Fuck *** Mode",
+            type: "switch",
+            description: "把歌词里的 f**k 等屏蔽词还原为原词",
+            value: computed({
+              get: () => settingStore.uncensorMaskedProfanity,
+              set: (v) => (settingStore.uncensorMaskedProfanity = v),
+            }),
+          },
+          {
             key: "audioEngine",
             label: "音频处理引擎",
             type: "select",

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -807,11 +807,12 @@ class LyricManager {
   private setFinalLyric(lyricData: SongLyric, req: number) {
     const musicStore = useMusicStore();
     const statusStore = useStatusStore();
+    const settingStore = useSettingStore();
     // 若非本次
     if (this.activeLyricReq !== req) return;
     // 应用括号替换
     lyricData = applyBracketReplacement(lyricData);
-    lyricData = applyProfanityUncensor(lyricData);
+    lyricData = applyProfanityUncensor(lyricData, settingStore.uncensorMaskedProfanity);
     // 规范化时间
     this.normalizeLyricLines(lyricData.yrcData);
     this.normalizeLyricLines(lyricData.lrcData);

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -7,6 +7,7 @@ import type { LyricPriority, SongLyric } from "@/types/lyric";
 import type { SongType } from "@/types/main";
 import { isElectron } from "@/utils/env";
 import { applyBracketReplacement } from "@/utils/lyric/lyricFormat";
+import { applyProfanityUncensor } from "@/utils/lyric/lyricProfanity";
 import {
   alignLyrics,
   isWordLevelFormat,
@@ -810,6 +811,7 @@ class LyricManager {
     if (this.activeLyricReq !== req) return;
     // 应用括号替换
     lyricData = applyBracketReplacement(lyricData);
+    lyricData = applyProfanityUncensor(lyricData);
     // 规范化时间
     this.normalizeLyricLines(lyricData.yrcData);
     this.normalizeLyricLines(lyricData.lrcData);

--- a/src/stores/migrations/settingMigrations.ts
+++ b/src/stores/migrations/settingMigrations.ts
@@ -6,7 +6,7 @@ import type { SettingState } from "../setting";
 /**
  * 当前设置 Schema 版本号
  */
-export const CURRENT_SETTING_SCHEMA_VERSION = 10;
+export const CURRENT_SETTING_SCHEMA_VERSION = 11;
 
 /**
  * 迁移函数类型
@@ -185,5 +185,10 @@ export const settingMigrations: Record<number, MigrationFunction> = {
     }
     const oldState = state as OldSettingState;
     return oldState.clearSearchOnBlur === true ? { searchInputBehavior: "clear" } : {};
+  },
+  11: () => {
+    return {
+      uncensorMaskedProfanity: false,
+    };
   },
 };

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -108,6 +108,7 @@ export interface SettingState {
   hideBracketedContent: boolean;
   /** 替换歌词括号内容 */
   replaceLyricBrackets: boolean;
+  uncensorMaskedProfanity: boolean;
   /** 歌词括号替换预设 */
   bracketReplacementPreset: "dash" | "angleBrackets" | "cornerBrackets" | "custom";
   /** 自定义歌词括号替换内容 */
@@ -597,6 +598,7 @@ export const useSettingStore = defineStore("setting", {
     lyricAlignRight: false,
     hideBracketedContent: false,
     replaceLyricBrackets: false,
+    uncensorMaskedProfanity: false,
     bracketReplacementPreset: "dash",
     customBracketReplacement: "-",
     enableExcludeLyrics: true,

--- a/src/utils/lyric/lyricProfanity.ts
+++ b/src/utils/lyric/lyricProfanity.ts
@@ -1,0 +1,44 @@
+import { useSettingStore } from "@/stores";
+import type { SongLyric } from "@/types/lyric";
+import type { LyricLine } from "@applemusic-like-lyrics/lyric";
+import { cloneDeep } from "lodash-es";
+
+const replaceMaskedProfanity = (text: string) => {
+  if (!text) return text;
+  return text
+    .replace(/f\*{2}k/gi, "fuck")
+    .replace(/s\*{2}t/gi, "shit")
+    .replace(/c\*{2}t/gi, "cunt")
+    .replace(/c\*{2}k/gi, "cock")
+    .replace(/co\*{2}/gi, "cock")
+    .replace(/s\*{2}ker/gi, "sucker")
+    .replace(/\*{4}ing/gi, "fucking")
+    .replace(/b\*{3}h/gi, "bitch")
+    .replace(/d\*{2}k/gi, "dick")
+    .replace(/d\*{2}n/gi, "damn")
+    .replace(/\*{4}er/gi, "fucker")
+    .replace(/as\*{2}le/gi, "asshole")
+    .replace(/w\*{3}e/gi, "whore")
+    .replace(/n\*{3}a/gi, "nigga");
+};
+
+const processLine = (line: LyricLine) => {
+  if (line.words) {
+    line.words.forEach((w) => {
+      w.word = replaceMaskedProfanity(w.word);
+      if (w.romanWord) w.romanWord = replaceMaskedProfanity(w.romanWord);
+    });
+  }
+  if (line.translatedLyric) line.translatedLyric = replaceMaskedProfanity(line.translatedLyric);
+  if (line.romanLyric) line.romanLyric = replaceMaskedProfanity(line.romanLyric);
+};
+
+export const applyProfanityUncensor = (lyricData: SongLyric): SongLyric => {
+  const settingStore = useSettingStore();
+  if (!settingStore.uncensorMaskedProfanity) return lyricData;
+
+  const newLyricData = cloneDeep(lyricData);
+  newLyricData.lrcData?.forEach(processLine);
+  newLyricData.yrcData?.forEach(processLine);
+  return newLyricData;
+};

--- a/src/utils/lyric/lyricProfanity.ts
+++ b/src/utils/lyric/lyricProfanity.ts
@@ -1,4 +1,3 @@
-import { useSettingStore } from "@/stores";
 import type { SongLyric } from "@/types/lyric";
 import type { LyricLine } from "@applemusic-like-lyrics/lyric";
 import { cloneDeep } from "lodash-es";
@@ -33,9 +32,8 @@ const processLine = (line: LyricLine) => {
   if (line.romanLyric) line.romanLyric = replaceMaskedProfanity(line.romanLyric);
 };
 
-export const applyProfanityUncensor = (lyricData: SongLyric): SongLyric => {
-  const settingStore = useSettingStore();
-  if (!settingStore.uncensorMaskedProfanity) return lyricData;
+export const applyProfanityUncensor = (lyricData: SongLyric, uncensor: boolean): SongLyric => {
+  if (!uncensor) return lyricData;
 
   const newLyricData = cloneDeep(lyricData);
   newLyricData.lrcData?.forEach(processLine);


### PR DESCRIPTION
添加设置选项以还原歌词中的屏蔽词（如 f**k 还原为 fuck）。新增迁移函数、设置状态、UI 开关及歌词处理逻辑。