### PR TITLE
增强文本可选功能和别名显示

### DIFF
--- a/src/components/Card/SongCard.vue
+++ b/src/components/Card/SongCard.vue
@@ -38,15 +38,20 @@
               }"
               class="name-text"
             >
-              <span class="user-select-text" v-text="settingStore.hideBracketedContent
-                  ? removeBrackets(song?.name)
-                  : song?.name || '未知曲目'"/>
+              <span
+                class="user-select-text"
+                v-text="
+                  settingStore.hideBracketedContent
+                    ? removeBrackets(song?.name)
+                    : song?.name || '未知曲目'
+                "
+              />
               <n-text
                 v-if="song.alia?.length && !settingStore.hideBracketedContent"
-                class="alia"
+                class="alia user-select-text"
                 depth="3"
               >
-                (<span class="user-select-text" v-text="song.alia"/>)
+                {{ song.alia }}
               </n-text>
             </n-ellipsis>
           </div>
@@ -357,6 +362,14 @@ const albumName = computed(() => {
         align-items: center;
         line-height: normal;
         font-size: 16px;
+        .alia {
+          &::before {
+            content: " (";
+          }
+          &::after {
+            content: ") ";
+          }
+        }
       }
       .desc {
         min-width: 0;

--- a/src/components/Card/SongCard.vue
+++ b/src/components/Card/SongCard.vue
@@ -65,7 +65,7 @@
             <!-- 原唱翻唱 -->
             <template v-if="settingStore.showSongOriginalTag">
               <n-tag v-if="song.originCoverType === 1" :bordered="false" type="primary" round>
-                原
+                原唱
               </n-tag>
               <n-tag v-if="song.originCoverType === 2" :bordered="false" type="info" round>
                 翻唱

--- a/src/components/Card/SongCard.vue
+++ b/src/components/Card/SongCard.vue
@@ -38,17 +38,15 @@
               }"
               class="name-text"
             >
-              {{
-                settingStore.hideBracketedContent
+              <span class="user-select-text" v-text="settingStore.hideBracketedContent
                   ? removeBrackets(song?.name)
-                  : song?.name || "未知曲目"
-              }}
+                  : song?.name || '未知曲目'"/>
               <n-text
                 v-if="song.alia?.length && !settingStore.hideBracketedContent"
                 class="alia"
                 depth="3"
               >
-                ({{ song.alia }})
+                (<span class="user-select-text" v-text="song.alia"/>)
               </n-text>
             </n-ellipsis>
           </div>
@@ -113,7 +111,7 @@
             </n-tag>
             <!-- 歌手 -->
             <template v-if="settingStore.showSongArtist">
-              <div v-if="Array.isArray(song.artists)" class="artists">
+              <div v-if="Array.isArray(song.artists)" class="artists user-select-text">
                 <n-text
                   v-for="ar in song.artists"
                   :key="ar.id"
@@ -126,7 +124,7 @@
               <div v-else-if="song.type === 'radio'" class="artists">
                 <n-text class="ar"> 电台节目 </n-text>
               </div>
-              <div v-else class="artists" @click="openJumpArtist(song.artists)">
+              <div v-else class="artists user-select-text" @click="openJumpArtist(song.artists)">
                 <n-text class="ar">
                   {{
                     settingStore.hideBracketedContent
@@ -146,7 +144,7 @@
       >
         <n-text
           v-if="isObject(song.album)"
-          class="album-text"
+          class="album-text user-select-text"
           @click="
             router.push({
               name: 'album',
@@ -156,7 +154,7 @@
         >
           {{ albumName }}
         </n-text>
-        <n-text v-else class="album-text">
+        <n-text v-else class="album-text user-select-text">
           {{ albumName }}
         </n-text>
       </div>

--- a/src/components/List/ListDetail.vue
+++ b/src/components/List/ListDetail.vue
@@ -34,16 +34,20 @@
           </div>
         </div>
         <div class="data">
-          <n-h2 class="name user-select-text" @click="handleTitleClick">
+          <n-h2 class="name user-select-text">
             <n-ellipsis
               v-if="config.titleType === 'ellipsis'"
               :line-clamp="1"
               :tooltip="{ placement: 'bottom' }"
             >
-              {{ titleText }}
+              <span @click="handleTitleClick">
+                {{ titleText }}
+              </span>
             </n-ellipsis>
             <template v-else>
-              {{ titleText }}
+              <span @click="handleTitleClick">
+                {{ titleText }}
+              </span>
               <!-- 隐私歌单 -->
               <n-popover v-if="detailData?.privacy === 10" :show-arrow="false" placement="right">
                 <template #trigger>

--- a/src/components/List/ListDetail.vue
+++ b/src/components/List/ListDetail.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
         <div class="data">
-          <n-h2 class="name text-hidden user-select-text">
+          <n-h2 class="name user-select-text" @click="handleTitleClick">
             <n-ellipsis
               v-if="config.titleType === 'ellipsis'"
               :line-clamp="1"
@@ -53,6 +53,11 @@
               </n-popover>
             </template>
           </n-h2>
+          <n-collapse-transition class="collapse">
+            <n-text v-if="detailData?.alias?.length" class="name-alias user-select-text" depth="3">
+              <span v-for="(alia, index) in detailData.alias" :key="index" v-text="alia" />
+            </n-text>
+          </n-collapse-transition>
           <n-collapse-transition :show="!listScrolling" class="collapse">
             <!-- 简介 -->
             <n-text
@@ -312,6 +317,15 @@ const handleTagClick = (tag: string) => {
   });
 };
 
+// 处理标题点击
+const handleTitleClick = () => {
+  if (titleText.value) {
+    const title =
+      props.titleText || (props.config.titleType === "ellipsis" ? "专辑标题" : "节目标题");
+    openDescModal(titleText.value, title);
+  }
+};
+
 // 处理描述点击
 const handleDescriptionClick = () => {
   if (props.detailData?.description) {
@@ -443,10 +457,18 @@ const handleTabChange = (value: "songs" | "comments") => {
           transform: translateY(2px);
         }
       }
+      .name-alias {
+        &::before {
+          content: "(";
+        }
+        &::after {
+          content: ")";
+        }
+        span:not(:last-child)::after {
+          content: "; ";
+        }
+      }
       .collapse {
-        position: absolute;
-        left: 0;
-        top: 60px;
         margin-bottom: 12px;
       }
       .meta {

--- a/src/components/List/ListDetail.vue
+++ b/src/components/List/ListDetail.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
         <div class="data">
-          <n-h2 class="name text-hidden">
+          <n-h2 class="name text-hidden user-select-text">
             <n-ellipsis
               v-if="config.titleType === 'ellipsis'"
               :line-clamp="1"

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -103,6 +103,12 @@ audio {
   -webkit-line-clamp: 1;
 }
 
+// user-select-text
+.user-select-text {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 // tabs
 .n-tabs {
   width: 100%;

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -104,7 +104,9 @@ audio {
 }
 
 // user-select-text
-.user-select-text {
+*:has(> .user-select-text),
+.user-select-text,
+.user-select-text * {
   user-select: text;
   -webkit-user-select: text;
 }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -159,6 +159,7 @@ export type CoverType = {
   updateTime?: number;
   loading?: boolean;
   updateTip?: string;
+  alias?: string[];
   tracks?: {
     first: string;
     second: string;
@@ -189,7 +190,7 @@ export type ArtistType = {
   name: string;
   cover: string;
   coverSize?: CoverSize;
-  alia?: string;
+  alias?: string[];
   identify?: string;
   description?: string;
   albumSize?: number;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -145,6 +145,7 @@ export const formatCoverList = (data: any[]): CoverType[] => {
       duration: msToTime(item.duration || item.dt || item.playTime),
       createTime: item.createTime || item.publishTime,
       updateTime: item.updateTime || item.trackNumberUpdateTime || item.trackUpdateTime,
+      alias: [item.alias, item.transNames].flat().filter(Boolean),
       // 热榜特殊数据
       tracks: item.tracks,
     };
@@ -163,7 +164,7 @@ export const formatArtistsList = (data: any[]): ArtistType[] => {
     id: item.id,
     name: item.name,
     ...getCoverUrl(item),
-    alia: item.alias?.[0],
+    alias: [item.alias, item.transNames].flat().filter(Boolean),
     identify: item?.identifyTag?.[0],
     description: item.description || item.briefDesc,
     albumSize: item.albumSize,

--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -446,7 +446,7 @@ export const openDescModal = (content: string, title: string = "歌单简介") =
         { style: { maxHeight: "400px" } },
         {
           default: () =>
-            h("div", { style: { whiteSpace: "pre-wrap" } }, { default: () => content }),
+            h("div", { style: { whiteSpace: "pre-wrap", userSelect: "text" } }, { default: () => content }),
         },
       );
     },

--- a/src/views/Artist/layout.vue
+++ b/src/views/Artist/layout.vue
@@ -26,14 +26,14 @@
           />
         </div>
         <div class="data">
-          <div class="name text-hidden user-select-text">
+          <div class="name user-select-text">
             <n-text class="name-text">{{
               settingStore.hideBracketedContent
                 ? removeBrackets(artistDetailData.name)
                 : artistDetailData.name || "未知艺术家"
             }}</n-text>
-            <n-text v-if="artistDetailData?.alia" class="name-alias" depth="3">
-              {{ artistDetailData.alia || "未知艺术家" }}
+            <n-text v-if="artistDetailData?.alias?.length" class="name-alias" depth="3">
+              <span v-for="(alia, index) in artistDetailData.alias" :key="index" v-text="alia"/>
             </n-text>
           </div>
           <n-collapse-transition :show="!listScrolling" class="collapse">
@@ -359,7 +359,6 @@ watch(
         &:first-child {
           width: 60%;
           margin-top: 0;
-          height: 40px;
         }
       }
       .description {
@@ -370,18 +369,20 @@ watch(
       .name {
         font-size: 30px;
         font-weight: bold;
-        height: 48px;
         transition:
           font-size 0.3s var(--n-bezier),
           color 0.3s var(--n-bezier);
         .name-alias {
           &::before {
-            content: "（";
+            content: " (";
             margin-right: 6px;
           }
           &::after {
-            content: "）";
+            content: ") ";
             margin-left: 6px;
+          }
+          span:not(:last-child)::after {
+            content: "; ";
           }
         }
       }
@@ -391,8 +392,6 @@ watch(
         padding-left: 4px;
       }
       .collapse {
-        position: absolute;
-        top: 48px;
         margin: 8px 0;
       }
       .meta {

--- a/src/views/Artist/layout.vue
+++ b/src/views/Artist/layout.vue
@@ -26,7 +26,7 @@
           />
         </div>
         <div class="data">
-          <div class="name text-hidden">
+          <div class="name text-hidden user-select-text">
             <n-text class="name-text">{{
               settingStore.hideBracketedContent
                 ? removeBrackets(artistDetailData.name)

--- a/src/views/List/album.vue
+++ b/src/views/List/album.vue
@@ -198,10 +198,10 @@ const getAlbumDetail = async (id: number, refresh: boolean = false) => {
       backgroundCheck(id, cached);
       return;
     }
-  }
 
-  if (!refresh && detailData.value?.id !== id) {
-    resetData(true);
+    if (detailData.value?.id !== id) {
+      resetData(true);
+    }
   }
   // 获取专辑详情
   const detail = await albumDetail(id);


### PR DESCRIPTION
解决需求 [discussions/885](https://github.com/imsyy/SPlayer/discussions/885)

- 使歌单页面中的歌曲标题、别名、专辑名、歌手名可以选中复制
- 使专辑、歌手页面的名称以及别名可以选中复制，并更改了排版方便显示和选择
- 专辑页面文字太多时布局会乱所以单独显示
- 专辑页面标题太长会 hidden 所以添加了点击弹窗事件在弹窗中选择
- 一些别的更改

> [!NOTE]
> 歌单中的专辑只有原标题，别名加不上去，等别人来实现了

下面是一些例子：

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/303428c9-2e77-49c4-83c8-609f32c916a2" />
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/35e31523-c387-4e69-927f-f9f57d0c65ff" />
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/f41c5f94-7800-443b-a4c5-25fe1bcef9a9" />
