### PR TITLE
Add options for song title and artist info in lyrics copy feature

### DIFF
--- a/src/components/Modal/CopyLyrics.vue
+++ b/src/components/Modal/CopyLyrics.vue
@@ -19,20 +19,22 @@
         </n-list>
       </n-checkbox-group>
     </n-scrollbar>
-    <n-flex align="center" justify="space-between" class="footer">
-      <n-flex align="center">
-        <n-checkbox-group v-model:value="selectedFilters">
-          <n-flex align="center">
-            <n-checkbox value="translation" label="翻译" />
-            <n-checkbox value="romaji" label="音译" />
-            <n-checkbox value="emptyLine" label="空行" title="在每行歌词之间加入空行分隔" />
-            <n-checkbox value="songName" label="歌名" />
-            <n-checkbox value="artist" label="歌手" />
-          </n-flex>
-        </n-checkbox-group>
-      </n-flex>
-      <n-flex align="center">
-        <n-button @click="selectAll">全选</n-button>
+    <n-divider />
+    <n-flex vertical size="small" class="footer">
+      <n-text depth="2" class="footer-title">要复制的内容</n-text>
+      <n-checkbox-group v-model:value="selectedFilters">
+        <n-flex align="center" wrap :size="12" class="footer-options">
+          <n-checkbox value="translation" label="翻译" />
+          <n-checkbox value="romaji" label="音译" />
+          <n-checkbox value="emptyLine" label="空行" title="在每行歌词之间加入空行分隔" />
+          <n-checkbox value="songName" label="歌名" />
+          <n-checkbox value="artist" label="歌手" />
+        </n-flex>
+      </n-checkbox-group>
+      <n-flex justify="end" align="center" class="footer-actions">
+        <n-button @click="selectAll">
+          {{ isAllSelected ? "全不选" : "全选" }}
+        </n-button>
         <n-button type="primary" :disabled="selectedLines.length === 0" @click="handleCopy">
           复制 ({{ selectedLines.length }})
         </n-button>
@@ -73,6 +75,10 @@ const displayLyrics = computed(() => {
 
 const showTranslation = computed(() => selectedFilters.value.includes("translation"));
 const showRomaji = computed(() => selectedFilters.value.includes("romaji"));
+
+const isAllSelected = computed(
+  () => displayLyrics.value.length > 0 && selectedLines.value.length === displayLyrics.value.length,
+);
 
 const selectAll = () => {
   if (selectedLines.value.length === displayLyrics.value.length) {
@@ -145,9 +151,11 @@ const handleCopy = async () => {
   .lyric-content {
     font-size: 14px;
     line-height: 1.6;
+
     .translation {
       font-size: 12px;
     }
+
     .romaji {
       font-size: 12px;
       font-style: italic;
@@ -155,7 +163,22 @@ const handleCopy = async () => {
   }
 }
 
+.n-divider {
+  margin: 16px 0;
+}
+
 .footer {
-  margin-top: 20px;
+  .footer-title {
+    font-size: 13px;
+    margin-bottom: 4px;
+  }
+
+  .footer-options {
+    margin-bottom: 8px;
+  }
+
+  .footer-actions {
+    gap: 8px;
+  }
 }
 </style>

--- a/src/components/Modal/CopyLyrics.vue
+++ b/src/components/Modal/CopyLyrics.vue
@@ -26,6 +26,8 @@
             <n-checkbox value="translation" label="翻译" />
             <n-checkbox value="romaji" label="音译" />
             <n-checkbox value="emptyLine" label="空行" title="在每行歌词之间加入空行分隔" />
+            <n-checkbox value="songName" label="歌名" />
+            <n-checkbox value="artist" label="歌手" />
           </n-flex>
         </n-checkbox-group>
       </n-flex>
@@ -47,7 +49,7 @@ const props = defineProps<{ onClose: () => void }>();
 
 const musicStore = useMusicStore();
 
-const selectedFilters = ref<string[]>(["translation", "romaji", "emptyLine"]);
+const selectedFilters = ref<string[]>(["translation", "romaji", "emptyLine", "songName", "artist"]);
 const selectedLines = ref<number[]>([]);
 
 const rawLyrics = computed(() => {
@@ -84,7 +86,7 @@ const selectAll = () => {
  * 复制歌词
  */
 const handleCopy = async () => {
-  const linesToCopy = displayLyrics.value
+  let linesToCopy = displayLyrics.value
     .filter((l) => selectedLines.value.includes(l.index))
     .map((l) => {
       const parts: string[] = [];
@@ -95,6 +97,26 @@ const handleCopy = async () => {
     })
     .filter((s) => s)
     .join(selectedFilters.value.includes("emptyLine") ? "\n\n" : "\n");
+
+  const showSongName = selectedFilters.value.includes("songName");
+  const showArtist = selectedFilters.value.includes("artist");
+
+  if (showSongName || showArtist) {
+    const songName = musicStore.playSong.name;
+    const artistName = Array.isArray(musicStore.playSong.artists)
+      ? musicStore.playSong.artists.map((ar) => ar.name).join("/")
+      : musicStore.playSong.artists;
+
+    let suffix = "\n\n——";
+    if (showSongName && showArtist) {
+      suffix += `《${songName}》 - ${artistName}`;
+    } else if (showSongName) {
+      suffix += `《${songName}》`;
+    } else if (showArtist) {
+      suffix += ` ${artistName}`;
+    }
+    linesToCopy += suffix;
+  }
 
   if (linesToCopy) {
     await copyData(linesToCopy);

--- a/src/core/automix/AutomixManager.ts
+++ b/src/core/automix/AutomixManager.ts
@@ -510,7 +510,7 @@ export class AutomixManager {
 
     const { duration } = audioManager;
     if (!duration || duration <= 0) return;
-    let rawTime = audioManager.currentTime;
+    const rawTime = audioManager.currentTime;
     if (!Number.isFinite(rawTime) || rawTime < 0) return;
     const timeLeft = duration - rawTime;
     if (timeLeft < 0) return;


### PR DESCRIPTION
在复制歌词功能中添加可选的歌名和歌手信息显示。用户现在可以通过复选框选择是否在复制的歌词末尾添加歌曲名称和艺术家信息。默认情况下这两个选项为选中状态，以提供更好的上下文信息。