### PR TITLE
feat: 歌单拖拽排序功能

### DIFF
--- a/src/api/playlist.ts
+++ b/src/api/playlist.ts
@@ -140,6 +140,23 @@ export const likePlaylist = (id: number, t: number = 1 | 2) => {
 };
 
 /**
+ * 更新歌单中歌曲顺序
+ * @param {number} pid - 歌单 id
+ * @param {number[]} ids - 歌曲 id 数组（按新顺序排列）
+ */
+export const songOrderUpdate = (pid: number, ids: number[]) => {
+  return request({
+    url: "/song/order/update",
+    method: "post",
+    data: {
+      pid,
+      ids: JSON.stringify(ids),
+    },
+    params: { timestamp: Date.now() },
+  });
+};
+
+/**
  * 获取专辑排行榜数据
  * @param {boolean} [detail=true] 是否获取详情数据，默认为 true
  */

--- a/src/components/List/SongList.vue
+++ b/src/components/List/SongList.vue
@@ -90,21 +90,35 @@
             :items="virtualListItems"
             :height="`calc(100% - 40px)`"
             :padding-bottom="80"
+            :class="{ 'is-dragging-global': isDragging && draggable }"
             @scroll="onScroll"
           >
             <template #default="{ item, index }">
-              <SongCard
-                v-if="item.type === 'song'"
-                :song="item.data"
-                :index="index"
-                :hiddenCover="hiddenCover || settingStore.hiddenCovers.list"
-                :hiddenAlbum="hiddenAlbum"
-                :hiddenSize="hiddenSize"
-                @click.stop="handleSongClick(item.data)"
-                @dblclick.stop="handleSongPlay(item.data)"
-                @contextmenu.stop="handleShowMenu($event, item.data, index)"
-                @show-menu="handleShowMenu($event, item.data, index)"
-              />
+              <div v-if="item.type === 'song'" class="song-node">
+                <!-- 拖拽放置指示线 -->
+                <div
+                  v-if="isDragging && draggable && dropIndicator.index === index && dropIndicator.position === 'top'"
+                  class="drop-line line-top"
+                />
+                <div
+                  v-if="isDragging && draggable && dropIndicator.index === index && dropIndicator.position === 'bottom'"
+                  class="drop-line line-bottom"
+                />
+                <SongCard
+                  :class="{ 'is-dragging': isDragging && draggable && draggedIndex === index }"
+                  :song="item.data"
+                  :index="index"
+                  :hiddenCover="hiddenCover || settingStore.hiddenCovers.list"
+                  :hiddenAlbum="hiddenAlbum"
+                  :hiddenSize="hiddenSize"
+                  @mousedown="draggable ? handlePointerDown($event, index, item.data.name || '未知曲目') : undefined"
+                  @touchstart="draggable ? handlePointerDown($event, index, item.data.name || '未知曲目') : undefined"
+                  @click.stop="handleSongClick(item.data)"
+                  @dblclick.stop="handleSongPlay(item.data)"
+                  @contextmenu.stop="handleShowMenu($event, item.data, index)"
+                  @show-menu="handleShowMenu($event, item.data, index)"
+                />
+              </div>
               <!-- 加载更多 -->
               <div v-else-if="item.type === 'footer'" class="load-more">
                 <n-flex v-if="loadMore && loading">
@@ -139,6 +153,21 @@
           </div>
         </Transition>
       </Teleport>
+      <!-- 拖拽浮动标签 -->
+      <Teleport to="body">
+        <Transition name="fade">
+          <div
+            v-if="isDragging && draggable && dragLabelData"
+            class="drag-label"
+            :style="{
+              top: `${dragLabelPosition.top}px`,
+              left: `${dragLabelPosition.left}px`,
+            }"
+          >
+            <n-text class="drag-label-name">{{ dragLabelData.name }}</n-text>
+          </div>
+        </Transition>
+      </Teleport>
     </div>
     <!-- 列表加载 - 骨架屏 -->
     <div v-else-if="loading" class="song-list loading">
@@ -156,6 +185,7 @@ import { isEmpty } from "lodash-es";
 import { sortFieldOptions, sortOrderOptions } from "@/utils/meta";
 import { usePlayerController } from "@/core/player/PlayerController";
 import { useMobile } from "@/composables/useMobile";
+import { useDragSort } from "@/composables/List/useDragSort";
 import SongListMenu from "@/components/Menu/SongListMenu.vue";
 import MobileSongMenu from "@/components/Menu/MobileSongMenu.vue";
 import VirtualScroll from "@/components/UI/VirtualScroll.vue";
@@ -194,6 +224,8 @@ const props = withDefaults(
     listVersion?: string | number;
     /** 禁用高度过渡动画 */
     disableHeightTransition?: boolean;
+    /** 是否可拖拽排序 */
+    draggable?: boolean;
   }>(),
   {
     type: "song",
@@ -211,6 +243,8 @@ const emit = defineEmits<{
   scroll: [e: Event];
   // 删除歌曲
   removeSong: [id: number[]];
+  // 拖拽重排序
+  reorder: [fromIndex: number, toIndex: number];
 }>();
 
 const musicStore = useMusicStore();
@@ -218,6 +252,27 @@ const statusStore = useStatusStore();
 const settingStore = useSettingStore();
 const player = usePlayerController();
 const { isSmallScreen } = useMobile();
+
+// 列表元素
+const listRef = ref<InstanceType<typeof VirtualScroll> | null>(null);
+const songListRef = ref<HTMLElement | null>(null);
+
+// 拖拽排序
+const {
+  isDragging,
+  draggedIndex,
+  dropIndicator,
+  dragLabelData,
+  dragLabelPosition,
+  handlePointerDown,
+} = useDragSort({
+  virtualScrollRef: listRef,
+  itemCount: computed(() => props.data.length),
+  onReorder: (from, to) => emit("reorder", from, to),
+  paddingTop: 0,
+  triggerMode: "longpress",
+  longPressDelay: 300,
+});
 
 // 处理移动端单击播放
 const handleSongClick = (song: SongType) => {
@@ -238,10 +293,6 @@ const handleSongPlay = (song: SongType) => {
 // 列表状态
 const scrollTop = ref<number>(0);
 const scrollIndex = ref<number>(0);
-
-// 列表元素
-const listRef = ref<InstanceType<typeof VirtualScroll> | null>(null);
-const songListRef = ref<HTMLElement | null>(null);
 
 // 悬浮工具
 const floatToolShow = ref<boolean>(true);
@@ -634,6 +685,75 @@ onBeforeUnmount(() => {
     }
   }
 }
+
+// 拖拽排序
+.song-node {
+  position: relative;
+
+  .drop-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background-color: var(--primary-hex);
+    border-radius: 2px;
+    z-index: 10;
+    pointer-events: none;
+
+    &.line-top {
+      top: 0;
+    }
+    &.line-bottom {
+      bottom: 0;
+    }
+  }
+
+  :deep(.song-card) {
+    transition:
+      opacity 0.2s,
+      transform 0.3s;
+
+    &.is-dragging {
+      opacity: 0.3;
+      transform: scale(0.98);
+      .song-content {
+        border-color: rgba(var(--primary), 0.5);
+      }
+    }
+  }
+}
+
+:deep(.is-dragging-global) {
+  cursor: grabbing;
+
+  * {
+    cursor: grabbing;
+  }
+
+  .song-card {
+    pointer-events: none;
+  }
+}
+
+.drag-label {
+  position: fixed;
+  z-index: 9999;
+  padding: 8px 16px;
+  border-radius: 20px;
+  background-color: rgba(var(--primary), 0.15);
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+  transform: translate(12px, 12px);
+
+  max-width: 260px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(var(--text-color), 0.3);
+}
+
 .sort-menu {
   display: flex;
   padding: 12px;

--- a/src/components/List/SongPlayList.vue
+++ b/src/components/List/SongPlayList.vue
@@ -60,8 +60,8 @@
                 <!-- 拖拽手柄 -->
                 <div
                   class="drag-handle"
-                  @mousedown="handleDragStart($event, index, songData)"
-                  @touchstart.passive="handleDragStart($event, index, songData)"
+                  @mousedown="handlePointerDown($event, index, songData.name || '未知曲目')"
+                  @touchstart.passive="handlePointerDown($event, index, songData.name || '未知曲目')"
                   @click.stop
                 >
                   <SvgIcon :size="20" name="Menu" />
@@ -167,8 +167,8 @@
 import VirtualScroll from "@/components/UI/VirtualScroll.vue";
 import { usePlayerController } from "@/core/player/PlayerController";
 import { useDataStore, useSettingStore, useStatusStore } from "@/stores";
-import type { SongType } from "@/types/main";
 import { removeBrackets } from "@/utils/format";
+import { useDragSort } from "@/composables/List/useDragSort";
 
 const dataStore = useDataStore();
 const statusStore = useStatusStore();
@@ -206,166 +206,19 @@ const cleanPlayList = () => {
   });
 };
 
-const isDragging = ref(false);
-const draggedIndex = ref(-1);
-const targetIndex = ref(-1);
-const dropIndicator = reactive({ index: -1, position: "none" });
-
-const dragLabelData = ref<SongType | null>(null);
-const dragLabelPosition = reactive({ top: 0, left: 0 });
-
-let listRect: DOMRect | null = null;
-let autoScrollRafId: number | null = null;
-
-const handleDragStart = (e: MouseEvent | TouchEvent, index: number, item: SongType) => {
-  if (e.type === "mousedown") {
-    e.preventDefault();
-  }
-
-  isDragging.value = true;
-  draggedIndex.value = index;
-  targetIndex.value = index;
-  dragLabelData.value = item;
-
-  const wrapper = playListRef.value?.wrapperRef;
-  if (wrapper) {
-    listRect = wrapper.getBoundingClientRect();
-  }
-
-  updateDragLabelPosition(e);
-
-  window.addEventListener("mousemove", handleDragMove);
-  window.addEventListener("touchmove", handleDragMove, { passive: false });
-  window.addEventListener("mouseup", handleDragEnd);
-  window.addEventListener("touchend", handleDragEnd);
-};
-
-const handleDragMove = (e: MouseEvent | TouchEvent) => {
-  if (!isDragging.value) return;
-  if (e.cancelable) e.preventDefault();
-
-  updateDragLabelPosition(e);
-
-  if (!listRect) return;
-  const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
-
-  handleAutoScroll(clientY, listRect);
-
-  calculateTargetIndex(clientY);
-};
-
-const handleDragEnd = () => {
-  if (draggedIndex.value !== targetIndex.value && targetIndex.value !== -1) {
-    player.moveSong(draggedIndex.value, targetIndex.value);
-  }
-
-  cleanupDragState();
-};
-
-const cleanupDragState = () => {
-  stopAutoScroll();
-
-  isDragging.value = false;
-  draggedIndex.value = -1;
-  targetIndex.value = -1;
-  dropIndicator.index = -1;
-  dropIndicator.position = "none";
-  dragLabelData.value = null;
-
-  window.removeEventListener("mousemove", handleDragMove);
-  window.removeEventListener("touchmove", handleDragMove);
-  window.removeEventListener("mouseup", handleDragEnd);
-  window.removeEventListener("touchend", handleDragEnd);
-};
-
-const calculateTargetIndex = (clientY: number) => {
-  if (!listRect || !playListRef.value) return;
-
-  const currentScrollTop = playListRef.value.getScrollTop() || 0;
-  const paddingTop = 16;
-  const relativeY = clientY - listRect.top + currentScrollTop - paddingTop;
-  const dropInfo = playListRef.value.getDropInfoByOffset(relativeY);
-
-  let gapIndex = dropInfo.index;
-  if (dropInfo.position === "bottom") {
-    gapIndex += 1;
-  }
-
-  const maxGap = dataStore.playList.length;
-  gapIndex = Math.max(0, Math.min(gapIndex, maxGap));
-
-  if (gapIndex === maxGap) {
-    dropIndicator.index = maxGap - 1;
-    dropIndicator.position = "bottom";
-  } else {
-    dropIndicator.index = gapIndex;
-    dropIndicator.position = "top";
-  }
-
-  let insertIndex = draggedIndex.value;
-
-  if (draggedIndex.value < gapIndex) {
-    insertIndex = gapIndex - 1;
-  } else if (draggedIndex.value > gapIndex) {
-    insertIndex = gapIndex;
-  }
-
-  targetIndex.value = Math.max(0, Math.min(insertIndex, maxGap - 1));
-};
-
-const updateDragLabelPosition = (e: MouseEvent | TouchEvent) => {
-  const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
-  const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
-
-  dragLabelPosition.left = clientX;
-  dragLabelPosition.top = clientY;
-};
-
-const handleAutoScroll = (clientY: number, rect: DOMRect) => {
-  const edgeThreshold = 40;
-  const scrollSpeed = 12;
-
-  if (clientY < rect.top + edgeThreshold) {
-    startAutoScroll(-scrollSpeed);
-  } else if (clientY > rect.bottom - edgeThreshold) {
-    startAutoScroll(scrollSpeed);
-  } else {
-    stopAutoScroll();
-  }
-};
-
-const startAutoScroll = (amount: number) => {
-  if (autoScrollRafId !== null) return;
-
-  let expectedScroll = playListRef.value?.getScrollTop() || 0;
-
-  const scrollStep = () => {
-    if (!isDragging.value) return stopAutoScroll();
-
-    const actualScroll = playListRef.value?.getScrollTop() || 0;
-    if (Math.abs(actualScroll - expectedScroll) > Math.abs(amount) * 3) {
-      expectedScroll = actualScroll;
-    }
-
-    expectedScroll = Math.max(0, expectedScroll + amount);
-    playListRef.value?.scrollTo(expectedScroll, "auto");
-
-    calculateTargetIndex(dragLabelPosition.top);
-
-    autoScrollRafId = requestAnimationFrame(scrollStep);
-  };
-  autoScrollRafId = requestAnimationFrame(scrollStep);
-};
-
-const stopAutoScroll = () => {
-  if (autoScrollRafId !== null) {
-    cancelAnimationFrame(autoScrollRafId);
-    autoScrollRafId = null;
-  }
-};
-
-onUnmounted(() => {
-  cleanupDragState();
+const {
+  isDragging,
+  draggedIndex,
+  dropIndicator,
+  dragLabelData,
+  dragLabelPosition,
+  handlePointerDown,
+} = useDragSort({
+  virtualScrollRef: playListRef,
+  itemCount: computed(() => dataStore.playList.length),
+  onReorder: (from, to) => player.moveSong(from, to),
+  paddingTop: 16,
+  triggerMode: "handle",
 });
 </script>
 

--- a/src/composables/List/useDragSort.ts
+++ b/src/composables/List/useDragSort.ts
@@ -1,0 +1,295 @@
+import type { ComputedRef, Ref } from "vue";
+import type VirtualScroll from "@/components/UI/VirtualScroll.vue";
+
+export interface DragSortOptions {
+  /** VirtualScroll 组件实例引用 */
+  virtualScrollRef: Ref<InstanceType<typeof VirtualScroll> | null>;
+  /** 列表项总数 */
+  itemCount: ComputedRef<number>;
+  /** 排序完成回调 */
+  onReorder: (fromIndex: number, toIndex: number) => void;
+  /** 滚动区域顶部内边距 */
+  paddingTop?: number;
+  /** 触发模式: handle（手柄点击立即触发）| longpress（长按触发） */
+  triggerMode?: "handle" | "longpress";
+  /** 长按延迟毫秒数，默认 300 */
+  longPressDelay?: number;
+}
+
+export const useDragSort = (options: DragSortOptions) => {
+  const {
+    virtualScrollRef,
+    itemCount,
+    onReorder,
+    paddingTop = 0,
+    triggerMode = "handle",
+    longPressDelay = 300,
+  } = options;
+
+  const isDragging = ref(false);
+  const draggedIndex = ref(-1);
+  const targetIndex = ref(-1);
+  const dropIndicator = reactive({ index: -1, position: "none" });
+
+  const dragLabelData = ref<{ name: string } | null>(null);
+  const dragLabelPosition = reactive({ top: 0, left: 0 });
+
+  let listRect: DOMRect | null = null;
+  let autoScrollRafId: number | null = null;
+
+  // 长按相关
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingIndex = -1;
+  let pendingLabelText = "";
+  let pointerStartX = 0;
+  let pointerStartY = 0;
+  const MOVE_THRESHOLD = 5;
+
+  // ---- 核心拖拽逻辑 ----
+
+  const activateDrag = (e: MouseEvent | TouchEvent, index: number, labelText: string) => {
+    if (e.type === "mousedown") {
+      e.preventDefault();
+    }
+
+    isDragging.value = true;
+    draggedIndex.value = index;
+    targetIndex.value = index;
+    dragLabelData.value = { name: labelText };
+
+    const wrapper = virtualScrollRef.value?.wrapperRef;
+    if (wrapper) {
+      listRect = wrapper.getBoundingClientRect();
+    }
+
+    updateDragLabelPosition(e);
+
+    window.addEventListener("mousemove", handleDragMove);
+    window.addEventListener("touchmove", handleDragMove, { passive: false });
+    window.addEventListener("mouseup", handleDragEnd);
+    window.addEventListener("touchend", handleDragEnd);
+  };
+
+  const handleDragMove = (e: MouseEvent | TouchEvent) => {
+    if (!isDragging.value) return;
+    if (e.cancelable) e.preventDefault();
+
+    updateDragLabelPosition(e);
+
+    // 每次移动时刷新 listRect，避免因布局变化导致位置偏差
+    const wrapper = virtualScrollRef.value?.wrapperRef;
+    if (wrapper) {
+      listRect = wrapper.getBoundingClientRect();
+    }
+
+    if (!listRect) return;
+    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+
+    handleAutoScroll(clientY, listRect);
+    calculateTargetIndex(clientY);
+  };
+
+  const handleDragEnd = () => {
+    if (draggedIndex.value !== targetIndex.value && targetIndex.value !== -1) {
+      onReorder(draggedIndex.value, targetIndex.value);
+    }
+
+    cleanupDragState();
+  };
+
+  const cleanupDragState = () => {
+    stopAutoScroll();
+    cancelLongPress();
+
+    isDragging.value = false;
+    draggedIndex.value = -1;
+    targetIndex.value = -1;
+    dropIndicator.index = -1;
+    dropIndicator.position = "none";
+    dragLabelData.value = null;
+
+    window.removeEventListener("mousemove", handleDragMove);
+    window.removeEventListener("touchmove", handleDragMove);
+    window.removeEventListener("mouseup", handleDragEnd);
+    window.removeEventListener("touchend", handleDragEnd);
+    window.removeEventListener("mousemove", handleLongPressMove);
+    window.removeEventListener("touchmove", handleLongPressMove);
+    window.removeEventListener("mouseup", handleLongPressCancel);
+    window.removeEventListener("touchend", handleLongPressCancel);
+  };
+
+  const calculateTargetIndex = (clientY: number, overrideScrollTop?: number) => {
+    if (!listRect || !virtualScrollRef.value) return;
+
+    const currentScrollTop = overrideScrollTop ?? (virtualScrollRef.value.getScrollTop() || 0);
+    const relativeY = clientY - listRect.top + currentScrollTop - paddingTop;
+    const dropInfo = virtualScrollRef.value.getDropInfoByOffset(relativeY);
+
+    let gapIndex = dropInfo.index;
+    if (dropInfo.position === "bottom") {
+      gapIndex += 1;
+    }
+
+    const maxGap = itemCount.value;
+    gapIndex = Math.max(0, Math.min(gapIndex, maxGap));
+
+    if (gapIndex === maxGap) {
+      dropIndicator.index = maxGap - 1;
+      dropIndicator.position = "bottom";
+    } else {
+      dropIndicator.index = gapIndex;
+      dropIndicator.position = "top";
+    }
+
+    let insertIndex = draggedIndex.value;
+
+    if (draggedIndex.value < gapIndex) {
+      insertIndex = gapIndex - 1;
+    } else if (draggedIndex.value > gapIndex) {
+      insertIndex = gapIndex;
+    }
+
+    targetIndex.value = Math.max(0, Math.min(insertIndex, maxGap - 1));
+  };
+
+  const updateDragLabelPosition = (e: MouseEvent | TouchEvent) => {
+    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
+    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+
+    dragLabelPosition.left = clientX;
+    dragLabelPosition.top = clientY;
+  };
+
+  // ---- 自动滚动 ----
+
+  const handleAutoScroll = (clientY: number, rect: DOMRect) => {
+    const edgeThreshold = 40;
+    const scrollSpeed = 12;
+
+    if (clientY < rect.top + edgeThreshold) {
+      startAutoScroll(-scrollSpeed);
+    } else if (clientY > rect.bottom - edgeThreshold) {
+      startAutoScroll(scrollSpeed);
+    } else {
+      stopAutoScroll();
+    }
+  };
+
+  const startAutoScroll = (amount: number) => {
+    if (autoScrollRafId !== null) return;
+
+    let expectedScroll = virtualScrollRef.value?.getScrollTop() || 0;
+
+    const scrollStep = () => {
+      if (!isDragging.value) return stopAutoScroll();
+
+      const actualScroll = virtualScrollRef.value?.getScrollTop() || 0;
+      if (Math.abs(actualScroll - expectedScroll) > Math.abs(amount) * 3) {
+        expectedScroll = actualScroll;
+      }
+
+      expectedScroll = Math.max(0, expectedScroll + amount);
+      virtualScrollRef.value?.scrollTo(expectedScroll, "auto");
+
+      // 刷新 listRect 并使用实际的滚动位置计算目标索引
+      const wrapper = virtualScrollRef.value?.wrapperRef;
+      if (wrapper) {
+        listRect = wrapper.getBoundingClientRect();
+      }
+      calculateTargetIndex(dragLabelPosition.top, expectedScroll);
+
+      autoScrollRafId = requestAnimationFrame(scrollStep);
+    };
+    autoScrollRafId = requestAnimationFrame(scrollStep);
+  };
+
+  const stopAutoScroll = () => {
+    if (autoScrollRafId !== null) {
+      cancelAnimationFrame(autoScrollRafId);
+      autoScrollRafId = null;
+    }
+  };
+
+  // ---- 长按逻辑 ----
+
+  const cancelLongPress = () => {
+    if (longPressTimer !== null) {
+      clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  };
+
+  const handleLongPressMove = (e: MouseEvent | TouchEvent) => {
+    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
+    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+    const dx = clientX - pointerStartX;
+    const dy = clientY - pointerStartY;
+
+    if (Math.sqrt(dx * dx + dy * dy) > MOVE_THRESHOLD) {
+      cancelLongPress();
+      window.removeEventListener("mousemove", handleLongPressMove);
+      window.removeEventListener("touchmove", handleLongPressMove);
+      window.removeEventListener("mouseup", handleLongPressCancel);
+      window.removeEventListener("touchend", handleLongPressCancel);
+    }
+  };
+
+  const handleLongPressCancel = () => {
+    cancelLongPress();
+    window.removeEventListener("mousemove", handleLongPressMove);
+    window.removeEventListener("touchmove", handleLongPressMove);
+    window.removeEventListener("mouseup", handleLongPressCancel);
+    window.removeEventListener("touchend", handleLongPressCancel);
+  };
+
+  // ---- 统一入口 ----
+
+  const handlePointerDown = (e: MouseEvent | TouchEvent, index: number, labelText: string) => {
+    if (triggerMode === "handle") {
+      activateDrag(e, index, labelText);
+      return;
+    }
+
+    // 长按模式
+    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
+    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+    pointerStartX = clientX;
+    pointerStartY = clientY;
+    pendingIndex = index;
+    pendingLabelText = labelText;
+
+    cancelLongPress();
+    longPressTimer = setTimeout(() => {
+      longPressTimer = null;
+      // 震动反馈
+      navigator.vibrate?.(50);
+      // 构造一个具有正确坐标的伪事件用于 activateDrag
+      activateDrag(e, pendingIndex, pendingLabelText);
+
+      // 移除长按阶段的监听，拖拽阶段的监听已在 activateDrag 中绑定
+      window.removeEventListener("mousemove", handleLongPressMove);
+      window.removeEventListener("touchmove", handleLongPressMove);
+      window.removeEventListener("mouseup", handleLongPressCancel);
+      window.removeEventListener("touchend", handleLongPressCancel);
+    }, longPressDelay);
+
+    window.addEventListener("mousemove", handleLongPressMove);
+    window.addEventListener("touchmove", handleLongPressMove, { passive: false });
+    window.addEventListener("mouseup", handleLongPressCancel);
+    window.addEventListener("touchend", handleLongPressCancel);
+  };
+
+  onUnmounted(() => {
+    cleanupDragState();
+  });
+
+  return {
+    isDragging,
+    draggedIndex,
+    dropIndicator,
+    dragLabelData,
+    dragLabelPosition,
+    handlePointerDown,
+    cleanupDragState,
+  };
+};

--- a/src/composables/List/useDragSort.ts
+++ b/src/composables/List/useDragSort.ts
@@ -47,8 +47,15 @@ export const useDragSort = (options: DragSortOptions) => {
 
   // ---- 核心拖拽逻辑 ----
 
+  const getPointerPos = (e: MouseEvent | TouchEvent) => {
+    if ("touches" in e && e.touches.length > 0) {
+      return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+    return { x: (e as MouseEvent).clientX, y: (e as MouseEvent).clientY };
+  };
+
   const activateDrag = (e: MouseEvent | TouchEvent, index: number, labelText: string) => {
-    if (e.type === "mousedown") {
+    if (e.cancelable) {
       e.preventDefault();
     }
 
@@ -83,7 +90,7 @@ export const useDragSort = (options: DragSortOptions) => {
     }
 
     if (!listRect) return;
-    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+    const { y: clientY } = getPointerPos(e);
 
     handleAutoScroll(clientY, listRect);
     calculateTargetIndex(clientY);
@@ -153,11 +160,9 @@ export const useDragSort = (options: DragSortOptions) => {
   };
 
   const updateDragLabelPosition = (e: MouseEvent | TouchEvent) => {
-    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
-    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
-
-    dragLabelPosition.left = clientX;
-    dragLabelPosition.top = clientY;
+    const { x, y } = getPointerPos(e);
+    dragLabelPosition.left = x;
+    dragLabelPosition.top = y;
   };
 
   // ---- 自动滚动 ----
@@ -220,10 +225,9 @@ export const useDragSort = (options: DragSortOptions) => {
   };
 
   const handleLongPressMove = (e: MouseEvent | TouchEvent) => {
-    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
-    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
-    const dx = clientX - pointerStartX;
-    const dy = clientY - pointerStartY;
+    const { x, y } = getPointerPos(e);
+    const dx = x - pointerStartX;
+    const dy = y - pointerStartY;
 
     if (Math.sqrt(dx * dx + dy * dy) > MOVE_THRESHOLD) {
       cancelLongPress();
@@ -251,10 +255,9 @@ export const useDragSort = (options: DragSortOptions) => {
     }
 
     // 长按模式
-    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
-    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
-    pointerStartX = clientX;
-    pointerStartY = clientY;
+    const { x, y } = getPointerPos(e);
+    pointerStartX = x;
+    pointerStartY = y;
     pendingIndex = index;
     pendingLabelText = labelText;
 

--- a/src/stores/local.ts
+++ b/src/stores/local.ts
@@ -252,6 +252,31 @@ const createLocalStore = () => {
   };
 
   /**
+   * 重排本地歌单中的歌曲顺序
+   * @param playlistId 歌单 ID
+   * @param fromIndex 源位置索引
+   * @param toIndex 目标位置索引
+   */
+  const reorderSongsInLocalPlaylist = async (
+    playlistId: number,
+    fromIndex: number,
+    toIndex: number,
+  ): Promise<boolean> => {
+    const playlist = localPlaylists.value.find((p) => p.id === playlistId);
+    if (!playlist) return false;
+    if (fromIndex < 0 || fromIndex >= playlist.songs.length) return false;
+    if (toIndex < 0 || toIndex >= playlist.songs.length) return false;
+    if (fromIndex === toIndex) return true;
+
+    const [movedId] = playlist.songs.splice(fromIndex, 1);
+    playlist.songs.splice(toIndex, 0, movedId);
+    playlist.updateTime = Date.now();
+
+    await saveLocalPlaylists();
+    return true;
+  };
+
+  /**
    * 判断是否为本地歌单 ID
    * @param id 歌单 ID
    */
@@ -280,6 +305,7 @@ const createLocalStore = () => {
     deleteLocalPlaylist,
     addSongsToLocalPlaylist,
     removeSongsFromLocalPlaylist,
+    reorderSongsInLocalPlaylist,
     getLocalPlaylistDetail,
     isLocalPlaylist,
   });

--- a/src/views/List/liked.vue
+++ b/src/views/List/liked.vue
@@ -22,9 +22,11 @@
         :loading="loading"
         :height="songListHeight"
         :playListId="playlistId"
+        :draggable="canDragSort"
         :doubleClickAction="searchData?.length ? 'add' : 'all'"
         @scroll="handleListScroll"
         @removeSong="removeSong"
+        @reorder="handleReorder"
       />
       <n-empty
         v-else
@@ -44,11 +46,11 @@
 import type { DropdownOption } from "naive-ui";
 import { SongType } from "@/types/main";
 import { songDetail } from "@/api/song";
-import { playlistDetail, playlistAllSongs } from "@/api/playlist";
+import { playlistDetail, playlistAllSongs, songOrderUpdate } from "@/api/playlist";
 import { formatCoverList, formatSongsList } from "@/utils/format";
 import { renderIcon, copyData, getShareUrl } from "@/utils/helper";
 import { isObject } from "lodash-es";
-import { useDataStore } from "@/stores";
+import { useDataStore, useStatusStore } from "@/stores";
 import { openBatchList, openUpdatePlaylist } from "@/utils/modal";
 import { updateUserLikePlaylist } from "@/utils/auth";
 import { useListDetail } from "@/composables/List/useListDetail";
@@ -57,6 +59,7 @@ import { useListScroll } from "@/composables/List/useListScroll";
 import { useListActions } from "@/composables/List/useListActions";
 
 const dataStore = useDataStore();
+const statusStore = useStatusStore();
 
 // 是否激活
 const isActivated = ref<boolean>(false);
@@ -78,6 +81,11 @@ const { playAllSongs: playAllSongsAction } = useListActions();
 
 // 歌单 ID
 const playlistId = computed<number>(() => Number(dataStore.userLikeData.playlists?.[0]?.id) || 0);
+
+// 是否可拖拽排序（默认排序 + 非搜索模式）
+const canDragSort = computed(() => {
+  return !searchValue.value && statusStore.listSortField === "default";
+});
 
 // 当前正在请求的歌单 ID，用于防止竞态条件
 const currentRequestId = ref<number>(0);
@@ -332,6 +340,36 @@ const playAllSongs = useDebounceFn(() => {
 const removeSong = (ids: number[]) => {
   if (!listData.value) return;
   setListData(listData.value.filter((song) => !ids.includes(song.id)));
+};
+
+// 拖拽重排序
+const handleReorder = async (fromIndex: number, toIndex: number) => {
+  if (fromIndex === toIndex) return;
+
+  // 乐观更新视图
+  const newList = [...listData.value];
+  const [moved] = newList.splice(fromIndex, 1);
+  newList.splice(toIndex, 0, moved);
+  setListData(newList);
+
+  // 持久化到服务端
+  try {
+    const ids = newList.map((s) => s.id);
+    const result = await songOrderUpdate(playlistId.value, ids);
+    if (result.code !== 200) {
+      window.$message.error("保存排序失败");
+      loadPlaylistData(playlistId.value, true);
+    } else {
+      // 更新缓存
+      if (detailData.value) {
+        dataStore.setLikeSongsList(detailData.value, newList);
+      }
+    }
+  } catch (error) {
+    console.error("Failed to update song order:", error);
+    window.$message.error("保存排序失败，请重试");
+    loadPlaylistData(playlistId.value, true);
+  }
 };
 
 onActivated(async () => {

--- a/src/views/List/playlist.vue
+++ b/src/views/List/playlist.vue
@@ -53,9 +53,11 @@
           :loading="loading"
           :height="songListHeight"
           :playListId="playlistId"
+          :draggable="canDragSort"
           :doubleClickAction="searchData?.length ? 'add' : 'all'"
           @scroll="handleListScroll"
           @removeSong="removeSong"
+          @reorder="handleReorder"
         />
         <n-empty
           v-else
@@ -85,11 +87,12 @@ import {
   playlistAllSongs,
   deletePlaylist,
   updatePlaylistPrivacy,
+  songOrderUpdate,
 } from "@/api/playlist";
 import { formatCoverList, formatSongsList } from "@/utils/format";
 import { renderIcon, copyData, getShareUrl } from "@/utils/helper";
 import { isLogin, toLikePlaylist, updateUserLikePlaylist } from "@/utils/auth";
-import { useDataStore, useLocalStore } from "@/stores";
+import { useDataStore, useLocalStore, useStatusStore } from "@/stores";
 import { openBatchList, openUpdatePlaylist } from "@/utils/modal";
 import { useListDetail } from "@/composables/List/useListDetail";
 import { useListSearch } from "@/composables/List/useListSearch";
@@ -100,6 +103,7 @@ import { useListDataCache, type ListCacheData } from "@/composables/List/useList
 const router = useRouter();
 const dataStore = useDataStore();
 const localStore = useLocalStore();
+const statusStore = useStatusStore();
 
 const {
   detailData,
@@ -147,6 +151,11 @@ const isUserPlaylist = computed(() => {
 // 是否处于收藏歌单
 const isLikePlaylist = computed(() => {
   return dataStore.userLikeData.playlists.some((playlist) => playlist.id === detailData.value?.id);
+});
+
+// 是否可拖拽排序（用户自建歌单 + 默认排序 + 非搜索模式）
+const canDragSort = computed(() => {
+  return isUserPlaylist.value && !searchValue.value && statusStore.listSortField === "default";
 });
 
 // 是否处于歌单页面
@@ -512,6 +521,49 @@ const removeSong = async (ids: number[]) => {
     }
   }
   setListData(listData.value.filter((song) => !ids.includes(song.id)));
+};
+
+// 拖拽重排序
+const handleReorder = async (fromIndex: number, toIndex: number) => {
+  if (fromIndex === toIndex) return;
+
+  // 乐观更新视图
+  const newList = [...listData.value];
+  const [moved] = newList.splice(fromIndex, 1);
+  newList.splice(toIndex, 0, moved);
+  setListData(newList);
+
+  if (isLocalPlaylist.value) {
+    // 本地歌单持久化
+    const success = await localStore.reorderSongsInLocalPlaylist(
+      playlistId.value,
+      fromIndex,
+      toIndex,
+    );
+    if (!success) {
+      window.$message.error("排序失败");
+      handleLocalPlaylist(playlistId.value);
+    }
+  } else {
+    // 在线歌单持久化
+    try {
+      const ids = newList.map((s) => s.id);
+      const result = await songOrderUpdate(playlistId.value, ids);
+      if (result.code !== 200) {
+        window.$message.error("保存排序失败");
+        getPlaylistDetail(playlistId.value, { getList: true, refresh: true });
+      } else {
+        // 更新缓存
+        if (detailData.value) {
+          saveCache("playlist", playlistId.value, detailData.value, newList);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to update song order:", error);
+      window.$message.error("保存排序失败，请重试");
+      getPlaylistDetail(playlistId.value, { getList: true, refresh: true });
+    }
+  }
 };
 
 // 编辑歌单


### PR DESCRIPTION
## Summary
- 新增 `useDragSort` composable，统一拖拽排序逻辑，支持 handle（手柄）和 longpress（长按）两种触发模式
- 播放列表侧边栏使用手柄拖拽，收藏/歌单页面使用长按拖拽
- 支持在线歌单（调用 `/song/order/update` API）和本地歌单的排序持久化
- 虚拟滚动列表兼容：自动滚动、插入位置计算、拖拽指示线