### PR TITLE
🐞fix(mac/statusbar): 修复 macOS 状态栏歌词显示失效及配置架构对齐问题

### DIFF
--- a/electron/main/ipc/ipc-mac-statusbar.ts
+++ b/electron/main/ipc/ipc-mac-statusbar.ts
@@ -1,5 +1,10 @@
 import type { LyricLine } from "@applemusic-like-lyrics/lyric";
-import { TASKBAR_IPC_CHANNELS, type SyncStatePayload, type SyncTickPayload } from "@shared";
+import {
+  TASKBAR_IPC_CHANNELS,
+  type SyncStatePayload,
+  type SyncTickPayload,
+  type TaskbarConfig,
+} from "@shared";
 import { ipcMain } from "electron";
 import { useStore } from "../store";
 import { getMainTray } from "../tray";
@@ -88,9 +93,9 @@ const updateMacStatusBarLyric = (forceUpdate: boolean = false) => {
     return;
   }
 
-  // 如果歌词数据为空，则清空标题并返回
+  // 如果歌词数据为空，则显示当前歌曲标题，避免空白
   if (macLyricLines.length === 0) {
-    tray.setTitle("");
+    tray.setTitle(getCurrentSongTitle());
     return;
   }
 
@@ -107,7 +112,7 @@ const updateMacStatusBarLyric = (forceUpdate: boolean = false) => {
           .map((w) => w.word ?? "")
           .join("")
           .trim()
-      : "";
+      : getCurrentSongTitle(); // 处于前奏或未匹配到歌词时，显示歌曲名
 
   tray.setTitle(currentLyric);
 };
@@ -151,27 +156,39 @@ export const initMacStatusBarIpc = () => {
     }
   });
 
+  // 注册任务栏配置通用处理器，确保 macOS 也能获取和设置配置
+  ipcMain.handle(TASKBAR_IPC_CHANNELS.GET_OPTION, () => store.get("taskbar"));
+
+  ipcMain.on(TASKBAR_IPC_CHANNELS.SET_OPTION, (_event, option: Partial<TaskbarConfig>) => {
+    if (!option) return;
+    Object.entries(option).forEach(([key, value]) => {
+      store.set(`taskbar.${key}`, value);
+    });
+    // macOS 模式下不处理窗口可见性，仅同步配置
+  });
+
   ipcMain.on(TASKBAR_IPC_CHANNELS.SYNC_STATE, (_event, payload: SyncStatePayload) => {
     switch (payload.type) {
       case "lyrics-loaded": {
-        // 仅更新歌词数据，不立即更新状态栏显示
+        // 更新歌词数据并立即刷新显示
         macLyricLines = payload.data.lines;
         macLastLyricIndex = -1;
+        updateMacStatusBarLyric(true);
         break;
       }
 
       case "playback-state":
         macIsPlaying = payload.data.isPlaying;
-        // 不在这里直接更新歌词，依赖 SYNC_TICK 来驱动
+        // 播放状态变更时，如果是播放中，等待 SYNC_TICK 或插值器驱动
+        // 如果是暂停状态，则停止插值器并进行一次最终更新
         if (!macIsPlaying) {
-          // 如果是暂停状态，则停止插值器并进行一次最终更新
           stopInterpolation();
-          updateMacStatusBarLyric();
+          updateMacStatusBarLyric(true);
         }
         break;
 
       case "full-hydration":
-        // 接收完整的状态，但歌词更新仍然依赖 SYNC_TICK
+        // 接收完整的状态，立即同步并刷新显示
         if (payload.data.lyrics) {
           macLyricLines = payload.data.lyrics.lines;
           macLastLyricIndex = -1;
@@ -183,6 +200,11 @@ export const initMacStatusBarIpc = () => {
             macCurrentTime = currentTime;
             macOffset = offset;
           }
+        }
+        // 同步后立即刷新一次
+        updateMacStatusBarLyric(true);
+        if (macIsPlaying) {
+          startInterpolation();
         }
         break;
     }

--- a/electron/main/ipc/ipc-mac-statusbar.ts
+++ b/electron/main/ipc/ipc-mac-statusbar.ts
@@ -1,5 +1,6 @@
 import type { LyricLine } from "@applemusic-like-lyrics/lyric";
 import {
+  DEFAULT_TASKBAR_CONFIG,
   TASKBAR_IPC_CHANNELS,
   type SyncStatePayload,
   type SyncTickPayload,
@@ -161,8 +162,14 @@ export const initMacStatusBarIpc = () => {
 
   ipcMain.on(TASKBAR_IPC_CHANNELS.SET_OPTION, (_event, option: Partial<TaskbarConfig>) => {
     if (!option) return;
+
+    // 安全过滤：仅允许写入 DEFAULT_TASKBAR_CONFIG 中定义的合法键
+    const allowedKeys = Object.keys(DEFAULT_TASKBAR_CONFIG);
+
     Object.entries(option).forEach(([key, value]) => {
-      store.set(`taskbar.${key}`, value);
+      if (allowedKeys.includes(key)) {
+        store.set(`taskbar.${key}`, value);
+      }
     });
     // macOS 模式下不处理窗口可见性，仅同步配置
   });

--- a/electron/main/ipc/ipc-taskbar.ts
+++ b/electron/main/ipc/ipc-taskbar.ts
@@ -1,4 +1,9 @@
-import { TASKBAR_IPC_CHANNELS, type SyncStatePayload, type TaskbarConfig } from "@shared";
+import {
+  DEFAULT_TASKBAR_CONFIG,
+  TASKBAR_IPC_CHANNELS,
+  type SyncStatePayload,
+  type TaskbarConfig,
+} from "@shared";
 import { app, ipcMain, nativeTheme } from "electron";
 import type EventEmitter from "node:events";
 import { useStore } from "../store";
@@ -45,12 +50,21 @@ const initTaskbarIpc = () => {
     TASKBAR_IPC_CHANNELS.SET_OPTION,
     (_event, option: Partial<TaskbarConfig>, pushToWindow = true) => {
       if (!option) return;
+
+      // 安全过滤：仅允许写入 DEFAULT_TASKBAR_CONFIG 中定义的合法键
+      const allowedKeys = Object.keys(DEFAULT_TASKBAR_CONFIG);
+
       // 增量更新
       const prev = getTaskbarConfig();
-      const next = { ...prev, ...option };
+      const next = { ...prev };
+
       Object.entries(option).forEach(([key, value]) => {
-        store.set(`taskbar.${key}`, value);
+        if (allowedKeys.includes(key)) {
+          store.set(`taskbar.${key}`, value);
+          (next as any)[key] = value;
+        }
       });
+
       // 推送到歌词窗口
       if (pushToWindow) {
         taskbarLyricManager.send(TASKBAR_IPC_CHANNELS.SYNC_STATE, {

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -1,3 +1,4 @@
+import { toRaw } from "vue";
 import { AudioErrorCode } from "@/core/audio-player/BaseAudioPlayer";
 import { useDataStore, useMusicStore, useSettingStore, useStatusStore } from "@/stores";
 import type { AudioSourceType, QualityType, SongType } from "@/types/main";

--- a/src/core/player/PlayerIpc.ts
+++ b/src/core/player/PlayerIpc.ts
@@ -1,3 +1,4 @@
+import { toRaw } from "vue";
 import { useMusicStore, useSettingStore } from "@/stores";
 import type { SongLyric } from "@/types/lyric";
 import { useLyricManager } from "./LyricManager";

--- a/src/stores/data.ts
+++ b/src/stores/data.ts
@@ -1,3 +1,4 @@
+import { toRaw } from "vue";
 import { defineStore } from "pinia";
 import type {
   SongType,


### PR DESCRIPTION
- 在 ipc-mac-statusbar.ts 中补全 TaskbarConfig 导入并注册 GET_OPTION 与 SET_OPTION 处理器，确保 macOS 平台对齐最新的任务栏配置架构。
- 优化歌词显示降级逻辑，在歌词为空或处于前奏阶段时自动显示歌曲标题，解决开启后什么都不显示的问题。
- 在 PlayerController.ts、PlayerIpc.ts 及 data.ts 中显式补回 toRaw 导入，防止因自动导入失效导致的 IPC 数据传输异常。
- 改进数据同步机制，确保在接收全量状态同步或新歌词加载信号后立即刷新状态栏显示，消除开启延迟。