### PR TITLE
✨ feat: 为评论区「抱一抱」功能添加开关和首次提示

### DIFF
--- a/src/components/List/CommentList.vue
+++ b/src/components/List/CommentList.vue
@@ -103,9 +103,10 @@ import { isLogin } from "@/utils/auth";
 import { openUserLogin } from "@/utils/modal";
 import emoji from "@/assets/data/emoji.json";
 import { commentLike, hugComment, getCommentHugList } from "@/api/comment";
-import { useDataStore } from "@/stores";
+import { useDataStore, useSettingStore } from "@/stores";
 
 const userStore = useDataStore();
+const settingStore = useSettingStore();
 
 const props = defineProps<{
   data: CommentType[];
@@ -164,13 +165,46 @@ const likeComment = debounce(async (data: CommentType) => {
 }, 300);
 
 // 双击抱一抱
+let hugTipDismissed = false;
 const handleDoubleClick = debounce(async (item: CommentType) => {
+  if (!settingStore.enableCommentHug) return;
+  // 首次双击提示
+  if (!settingStore.showedCommentHugTip) {
+    window.$dialog.warning({
+      title: "抱一抱",
+      content: "双击评论会向评论者发送「抱一抱」，是否继续？",
+      positiveText: "继续",
+      negativeText: hugTipDismissed ? "取消且不再提示" : "取消",
+      onPositiveClick: () => {
+        settingStore.showedCommentHugTip = true;
+        executeHug(item);
+      },
+      onNegativeClick: () => {
+        if (hugTipDismissed) {
+          settingStore.showedCommentHugTip = true;
+          settingStore.enableCommentHug = false;
+        }
+        hugTipDismissed = true;
+      },
+    });
+    return;
+  }
+  executeHug(item);
+}, 300);
+
+// 执行抱一抱
+const executeHug = async (item: CommentType) => {
   if (!isLogin()) {
     openUserLogin();
     return;
   }
-  // 本地歌曲不支持抱一抱
-  if (typeof props.resId !== "number") return;
+  // 仅歌曲评论支持抱一抱
+  if (typeof props.resId !== "number" || props.type !== 0) {
+    if (typeof props.resId === "number") {
+      window.$message.warning("仅歌曲评论支持抱一抱");
+    }
+    return;
+  }
   try {
     const result = await hugComment(userStore.userData.userId, item.id, props.resId);
     if (result.code === 200) {
@@ -207,7 +241,7 @@ const handleDoubleClick = debounce(async (item: CommentType) => {
     console.error("Hug comment error:", error);
     window.$message.error("抱一抱失败");
   }
-}, 300);
+};
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/List/CommentList.vue
+++ b/src/components/List/CommentList.vue
@@ -166,6 +166,9 @@ const likeComment = debounce(async (data: CommentType) => {
 
 // 双击抱一抱
 let hugTipDismissed = false;
+watch(() => settingStore.enableCommentHug, (v) => {
+  if (v) hugTipDismissed = false;
+});
 const handleDoubleClick = debounce(async (item: CommentType) => {
   if (!settingStore.enableCommentHug) return;
   // 首次双击提示

--- a/src/components/Setting/config/general.ts
+++ b/src/components/Setting/config/general.ts
@@ -363,6 +363,19 @@ export const useGeneralSettings = (): SettingConfig => {
         title: "其他设置",
         items: [
           {
+            key: "enableCommentHug",
+            label: "评论区抱一抱",
+            type: "switch",
+            description: "开启后双击评论即可向评论者发送抱一抱",
+            value: computed({
+              get: () => settingStore.enableCommentHug,
+              set: (v) => {
+                settingStore.enableCommentHug = v;
+                if (v) settingStore.showedCommentHugTip = false;
+              },
+            }),
+          },
+          {
             key: "shareUrlFormat",
             label: "分享链接格式",
             type: "select",

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -48,6 +48,10 @@ export interface SettingState {
   taskbarLyricUseThemeColor: boolean;
   /** 是否使用在线服务 */
   useOnlineService: boolean;
+  /** 评论区抱一抱 */
+  enableCommentHug: boolean;
+  /** 是否已显示过抱一抱提示 */
+  showedCommentHugTip: boolean;
   /** 分享链接格式 */
   shareUrlFormat: "web" | "mobile";
   /** 启动时检查更新 */
@@ -500,6 +504,8 @@ export const useSettingStore = defineStore("setting", {
     routeAnimation: "slide",
     playerExpandAnimation: "up",
     useOnlineService: true,
+    enableCommentHug: true,
+    showedCommentHugTip: false,
     shareUrlFormat: "web",
     showCloseAppTip: true,
     closeAppMethod: "hide",


### PR DESCRIPTION
- 在常规设置的其他设置中添加「评论区抱一抱」开关，默认开启
- 首次双击评论时弹出确认提示，避免用户误触
- 第二次取消时提供「取消且不再提示」选项，可直接关闭功能
- 重新开启开关时自动重置提示状态
- 限制抱一抱仅对歌曲评论生效，其他资源类型给出提示