### PR TITLE
🐞 fix: 修复播客电台跳转失败并优化播客信息展示

### DIFF
--- a/src/components/Player/MainPlayer.vue
+++ b/src/components/Player/MainPlayer.vue
@@ -97,8 +97,8 @@
               <!-- 歌手 -->
               <div v-else class="artists">
                 <TextContainer :speed="0.5" class="artists-container">
-                  <n-text v-if="musicStore.playSong.type === 'radio'" class="ar-item">
-                    播客电台
+                  <n-text v-if="musicStore.playSong.type === 'radio'" class="ar-item" @click="showCreatorTip">
+                    {{ musicStore.playSong.dj?.creator || "未知艺术家" }}
                   </n-text>
                   <template v-else-if="Array.isArray(musicStore.playSong.artists)">
                     <n-text
@@ -424,6 +424,9 @@ const instantLyrics = computed(() => {
     ? `${contentStr}（ ${content?.translatedLyric} ）`
     : contentStr || "";
 });
+
+// 暂不支持查看主播主页
+const showCreatorTip = () => window.$message.info("暂不支持查看主播主页");
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Player/PlayerMeta/PlayerData.vue
+++ b/src/components/Player/PlayerMeta/PlayerData.vue
@@ -106,7 +106,9 @@
       <div v-else class="artists">
         <SvgIcon :depth="3" name="Artist" size="20" />
         <div class="ar-list">
-          <span class="ar">{{ musicStore.playSong.dj?.creator || "未知艺术家" }}</span>
+          <span class="ar" @click="showCreatorTip">
+            {{ musicStore.playSong.dj?.creator || "未知艺术家" }}
+          </span>
         </div>
       </div>
       <!-- 专辑 -->
@@ -135,7 +137,7 @@
       <div
         v-if="musicStore.playSong.type === 'radio'"
         class="dj"
-        @click="jumpPage({ name: 'dj', query: { id: musicStore.playSong.dj?.id } })"
+        @click="jumpToRadio"
       >
         <SvgIcon :depth="3" name="Podcast" size="20" />
         <span class="name-text text-hidden">{{ musicStore.playSong.dj?.name || "播客电台" }}</span>
@@ -152,6 +154,7 @@ import { removeBrackets } from "@/utils/format";
 import { SongUnlockServer } from "@/core/player/SongManager";
 import { useLyricManager } from "@/core/player/LyricManager";
 import { usePlayerController } from "@/core/player/PlayerController";
+import { radioProgramDetail } from "@/api/radio";
 const props = defineProps<{
   /** 数据居中 */
   center?: boolean;
@@ -246,6 +249,36 @@ const jumpPage = debounce(
     if (!go) return;
     statusStore.showFullPlayer = false;
     router.push(go);
+  },
+  300,
+  {
+    leading: true,
+    trailing: false,
+  },
+);
+
+// 暂不支持查看主播主页
+const showCreatorTip = () => window.$message.info("暂不支持查看主播主页");
+
+// 跳转到播客电台页面
+const jumpToRadio = debounce(
+  async () => {
+    const song = musicStore.playSong;
+    let radioId = song.dj?.radioId;
+    // 兼容旧数据：通过节目详情 API 获取电台 ID
+    if (!radioId && song.id) {
+      try {
+        const res = await radioProgramDetail(song.id);
+        radioId = res.program?.radio?.id;
+        // 回写避免重复请求
+        if (radioId && song.dj) song.dj.radioId = radioId;
+      } catch (_e) {
+        // ignore
+      }
+    }
+    if (!radioId) return;
+    statusStore.showFullPlayer = false;
+    router.push({ name: "radio", query: { id: radioId } });
   },
   300,
   {

--- a/src/core/player/MediaSessionManager.ts
+++ b/src/core/player/MediaSessionManager.ts
@@ -235,12 +235,12 @@ class MediaSessionManager {
     return {
       title: song!.name,
       artist: isRadio
-        ? "播客电台"
+        ? song!.dj?.creator || "未知播客"
         : Array.isArray(song!.artists)
           ? song!.artists.map((a) => a.name).join("/")
           : String(song!.artists),
       album: isRadio
-        ? "播客电台"
+        ? song!.dj?.name || "未知播客"
         : typeof song!.album === "object"
           ? song!.album.name
           : String(song!.album),

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -9,6 +9,8 @@ export type MetaData = {
 
 export type DjData = {
   id: number;
+  /** 所属电台 ID */
+  radioId?: number;
   name: string;
   creator?: string;
 };

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -84,6 +84,7 @@ export const formatSongsList = (data: any[]): SongType[] => {
       dj: item.dj
         ? {
             id: item.mainTrackId || item.id,
+            radioId: item.radio?.id,
             name: item.dj?.brand,
             creator: item.dj?.nickname,
           }
@@ -358,7 +359,7 @@ export const getPlayerInfoObj = (
   // 歌手
   const artist =
     playSongData.type === "radio"
-      ? "播客电台"
+      ? playSongData.dj?.creator || "未知播客"
       : Array.isArray(playSongData.artists)
         ? playSongData.artists.map((artists: { name: string }) => artists.name).join(sep)
         : String(playSongData?.artists || "未知歌手");
@@ -366,7 +367,7 @@ export const getPlayerInfoObj = (
   // 专辑
   const album =
     playSongData.type === "radio"
-      ? "播客电台"
+      ? playSongData.dj?.name || "未知播客"
       : typeof playSongData.album === "object"
         ? playSongData.album.name
         : String(playSongData.album || "未知专辑");


### PR DESCRIPTION
- 修复全屏播放器点击播客条目无法跳转的问题（路由名称错误 + 电台 ID 缺失）
- 播客歌手栏显示主播名称，电台栏显示播客名称并支持跳转
- 任务栏歌词和系统媒体控制显示实际播客信息而非固定文本
- 点击主播名称时提示暂不支持查看主播主页