### PR TITLE
feat(lyric): 支持杜比全景声(6声道)TTML歌词偏移

### DIFF
--- a/electron/main/services/MpvService.ts
+++ b/electron/main/services/MpvService.ts
@@ -205,6 +205,7 @@ export class MpvService {
     this.observeProperty(3, "volume");
     this.observeProperty(4, "metadata");
     this.observeProperty(5, "duration");
+    this.observeProperty(6, "audio-params/channel-count");
   }
 
   private applyPendingVolume() {

--- a/src/core/audio-player/AudioElementPlayer.ts
+++ b/src/core/audio-player/AudioElementPlayer.ts
@@ -17,6 +17,8 @@ export class AudioElementPlayer extends BaseAudioPlayer {
   private audioElement: HTMLAudioElement;
   /** MediaElementAudioSourceNode 用于连接 Web Audio API */
   private sourceNode: MediaElementAudioSourceNode | null = null;
+  /** 当前音频声道数 */
+  private channels = 2;
 
   /** Seek 锁，用于在 seek 过程中返回稳定的 currentTime */
   private isInternalSeeking = false;
@@ -55,6 +57,8 @@ export class AudioElementPlayer extends BaseAudioPlayer {
       } else {
         this.sourceNode.disconnect();
       }
+
+      this.channels = this.sourceNode.channelCount;
 
       // 连接: Source -> Input
       this.sourceNode.connect(this.inputNode);
@@ -227,6 +231,10 @@ export class AudioElementPlayer extends BaseAudioPlayer {
       default:
         return 0;
     }
+  }
+
+  public getChannels(): number {
+    return this.channels;
   }
 
   /**

--- a/src/core/audio-player/IPlaybackEngine.ts
+++ b/src/core/audio-player/IPlaybackEngine.ts
@@ -218,6 +218,11 @@ export interface IPlaybackEngine {
   getErrorCode(): number;
 
   /**
+   * 获取音频声道数
+   */
+  getChannels?(): number;
+
+  /**
    * 添加事件监听
    */
   addEventListener(

--- a/src/core/audio-player/MpvPlayer.ts
+++ b/src/core/audio-player/MpvPlayer.ts
@@ -33,6 +33,7 @@ export class MpvPlayer extends EventTarget implements IPlaybackEngine {
   private _volume: number = 1;
   private _rate: number = 1;
   private _errorCode: number = 0;
+  private _channels: number = 2;
 
   /** 当前 loadfile 请求期望自动播放 */
   private autoPlayPending: boolean | null = null;
@@ -104,6 +105,12 @@ export class MpvPlayer extends EventTarget implements IPlaybackEngine {
           case "volume":
             if (typeof value === "number") {
               this._volume = value / 100;
+            }
+            break;
+
+          case "audio-params/channel-count":
+            if (typeof value === "number") {
+              this._channels = value;
             }
             break;
         }
@@ -192,6 +199,7 @@ export class MpvPlayer extends EventTarget implements IPlaybackEngine {
         this.forcePaused = false;
       }
       this._src = url;
+      this._channels = 2;
 
       // 设置期望的 seek 位置
       if (options?.seek && options.seek > 0) {
@@ -275,6 +283,10 @@ export class MpvPlayer extends EventTarget implements IPlaybackEngine {
 
   public getErrorCode(): number {
     return this._errorCode;
+  }
+
+  public getChannels(): number {
+    return this._channels;
   }
 
   // ========== 状态属性 ==========

--- a/src/core/audio-player/ffmpeg-engine/FFmpegAudioPlayer.ts
+++ b/src/core/audio-player/ffmpeg-engine/FFmpegAudioPlayer.ts
@@ -122,6 +122,10 @@ export class FFmpegAudioPlayer extends BaseAudioPlayer {
     return 0;
   }
 
+  public getChannels(): number {
+    return this.metadata?.channels ?? 2;
+  }
+
   private requestWorker<T = void>(
     msg: DistributiveOmit<WorkerRequest, "id">,
     transfer: Transferable[] = [],

--- a/src/core/player/AudioManager.ts
+++ b/src/core/player/AudioManager.ts
@@ -468,6 +468,13 @@ class AudioManager extends TypedEventTarget<AudioEventMap> implements IPlaybackE
   }
 
   /**
+   * 获取音频声道数
+   */
+  public getChannels(): number {
+    return this.engine.getChannels?.() ?? 2;
+  }
+
+  /**
    * 解除 MPV 强制暂停状态
    * 仅在 MPV 引擎下有效
    */

--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -19,7 +19,12 @@ import { parseLrc } from "@/utils/lyric/parseLrc";
 import { getConverter } from "@/utils/opencc";
 import { type LyricLine, parseTTML, parseYrc } from "@applemusic-like-lyrics/lyric";
 import { cloneDeep, isEmpty } from "lodash-es";
-import { attachTtmlBgLines, cleanTTMLTranslations } from "@/utils/lyric/parseTTML";
+import {
+  applyLyricOffsetToLines,
+  attachTtmlBgLines,
+  cleanTTMLTranslations,
+  extractTtmlLyricOffsetMs,
+} from "@/utils/lyric/parseTTML";
 
 interface LyricFetchResult {
   data: SongLyric;
@@ -49,6 +54,14 @@ class LyricManager {
    * 预加载的歌词
    */
   private prefetchedLyric: { id: number | string; result: LyricFetchResult } | null = null;
+
+  /**
+   * 判断是否应用 TTML 歌词偏移（仅杜比全景声6声道）
+   */
+  private shouldApplyTtmlOffset(): boolean {
+    const statusStore = useStatusStore();
+    return statusStore.currentAudioChannels === 6;
+  }
 
   constructor() {}
 
@@ -323,9 +336,12 @@ class LyricManager {
         }
       }
       if (!ttmlContent || typeof ttmlContent !== "string") return;
+      const lyricOffsetMs = this.shouldApplyTtmlOffset()
+        ? extractTtmlLyricOffsetMs(ttmlContent)
+        : 0;
       const sorted = cleanTTMLTranslations(ttmlContent);
       const parsed = parseTTML(sorted);
-      const lines = parsed?.lines || [];
+      const lines = applyLyricOffsetToLines(parsed?.lines || [], lyricOffsetMs);
       if (!lines.length) return;
 
       // 只有当没有 YRC 数据或优先级为 TTML 或 自动模式(TTML > QM) 时才覆盖
@@ -460,9 +476,10 @@ class LyricManager {
       }
       // TTML 直接返回
       if (format === "ttml") {
+        const lyricOffsetMs = this.shouldApplyTtmlOffset() ? extractTtmlLyricOffsetMs(lyric) : 0;
         const sorted = cleanTTMLTranslations(lyric);
         const ttml = parseTTML(sorted);
-        const lines = ttml?.lines || [];
+        const lines = applyLyricOffsetToLines(ttml?.lines || [], lyricOffsetMs);
         return {
           data: { lrcData: [], yrcData: lines },
           meta: { usingTTMLLyric: true, usingQRCLyric: false },
@@ -547,10 +564,12 @@ class LyricManager {
       try {
         const ttmlContent = typeof ttml === "string" ? ttml : "";
         if (ttmlContent) {
+          const lyricOffsetMs = this.shouldApplyTtmlOffset()
+            ? extractTtmlLyricOffsetMs(ttmlContent)
+            : 0;
           const cleaned = cleanTTMLTranslations(ttmlContent);
           const raw = parseTTML(cleaned).lines || [];
-          ttmlLines = raw;
-          console.log("检测到本地TTML歌词覆盖", ttmlLines);
+          ttmlLines = applyLyricOffsetToLines(raw, lyricOffsetMs);
         }
       } catch (err) {
         console.error("parseTTML 本地解析失败:", err);
@@ -838,9 +857,22 @@ class LyricManager {
 
     // 检查预加载缓存
     if (this.prefetchedLyric && this.prefetchedLyric.id === song.id) {
-      console.log(`🚀 [${song.id}] 使用预加载歌词`);
       const { data, meta } = this.prefetchedLyric.result;
       this.prefetchedLyric = null; // 消费后清除
+
+      // TTML 偏移与声道相关，预加载阶段可能不准确，命中时重新拉取
+      if (meta.usingTTMLLyric) {
+        try {
+          const refetched = await this.fetchLyric(song);
+          if (this.activeLyricReq !== req) return;
+          statusStore.usingTTMLLyric = refetched.meta.usingTTMLLyric;
+          statusStore.usingQRCLyric = refetched.meta.usingQRCLyric;
+          this.setFinalLyric(refetched.data, req);
+          return;
+        } catch {
+          // 回退使用预加载结果
+        }
+      }
 
       // 应用到 Store
       statusStore.usingTTMLLyric = meta.usingTTMLLyric;

--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -659,13 +659,39 @@ class PlayerController {
     // 加载状态
     audioManager.addEventListener("loadstart", () => {
       statusStore.playLoading = true;
+      statusStore.currentAudioChannels = undefined;
     });
 
     // 加载完成
     audioManager.addEventListener("canplay", () => {
       const playSongData = getPlaySongData();
+      const lyricManager = useLyricManager();
+      const syncChannelsAndRefreshLyric = () => {
+        const prevChannels = statusStore.currentAudioChannels;
+        const nextChannels = audioManager.getChannels();
+        statusStore.currentAudioChannels = nextChannels;
+
+        // 声道发生变化且当前使用 TTML 时，重新加载歌词确保偏移正确
+        if (
+          prevChannels !== nextChannels &&
+          statusStore.usingTTMLLyric &&
+          playSongData &&
+          playSongData.id === useMusicStore().playSong.id
+        ) {
+          lyricManager.handleLyric(playSongData).catch(() => {});
+        }
+      };
       // 结束加载
       statusStore.playLoading = false;
+      // 更新声道数信息
+      syncChannelsAndRefreshLyric();
+      // 间隔刷新：兼容不同引擎声道数延迟到达
+      setTimeout(() => {
+        syncChannelsAndRefreshLyric();
+      }, 200);
+      setTimeout(() => {
+        syncChannelsAndRefreshLyric();
+      }, 600);
       // 恢复 EQ
       if (isElectron && statusStore.eqEnabled) {
         const bands = statusStore.eqBands;

--- a/src/stores/status.ts
+++ b/src/stores/status.ts
@@ -70,6 +70,8 @@ interface StatusState {
   songQuality: QualityType | undefined;
   /** 当前歌曲音源 */
   audioSource: AudioSourceType | undefined;
+  /** 当前播放音频声道数 */
+  currentAudioChannels: number | undefined;
   /** 当前播放索引 */
   playIndex: number;
   /** 歌词播放索引 */
@@ -191,6 +193,7 @@ export const useStatusStore = defineStore("status", {
     usingQRCLyric: false,
     songQuality: undefined,
     audioSource: undefined,
+    currentAudioChannels: undefined,
     playIndex: -1,
     lyricIndex: -1,
     lyricLoading: false,

--- a/src/utils/lyric/parseTTML.ts
+++ b/src/utils/lyric/parseTTML.ts
@@ -59,6 +59,63 @@ const getRole = (el: Element): string => {
 };
 
 /**
+ * 提取 TTML metadata 中的歌词偏移（毫秒）
+ * @param ttml TTML 文本
+ * @returns 偏移毫秒，正数延后，负数提前
+ */
+export const extractTtmlLyricOffsetMs = (ttml: string): number => {
+  if (!ttml.trim()) return 0;
+  const doc = new DOMParser().parseFromString(ttml, "application/xml");
+  if (doc.getElementsByTagName("parsererror").length) return 0;
+
+  const audioNodes = Array.from(doc.getElementsByTagName("audio"));
+  for (const audio of audioNodes) {
+    const role = getRole(audio);
+    if (role !== "spatial") continue;
+
+    let inMetadata = false;
+    let cur: Element | null = audio.parentElement;
+    while (cur) {
+      const tag = cur.tagName.toLowerCase();
+      if (tag === "metadata" || tag.endsWith(":metadata")) {
+        inMetadata = true;
+        break;
+      }
+      cur = cur.parentElement;
+    }
+    if (!inMetadata) continue;
+
+    const rawOffset = audio.getAttribute("lyricOffset");
+    if (!rawOffset) continue;
+    const offsetSeconds = Number.parseFloat(rawOffset.trim());
+    if (!Number.isFinite(offsetSeconds)) continue;
+    return Math.round(offsetSeconds * 1000);
+  }
+
+  return 0;
+};
+
+/**
+ * 应用歌词偏移到逐字歌词行
+ * @param lines 歌词行
+ * @param offsetMs 偏移毫秒
+ * @returns 偏移后的歌词行
+ */
+export const applyLyricOffsetToLines = (lines: LyricLine[], offsetMs: number): LyricLine[] => {
+  if (!lines.length || !offsetMs) return lines;
+  return lines.map((line) => ({
+    ...line,
+    startTime: line.startTime + offsetMs,
+    endTime: line.endTime + offsetMs,
+    words: line.words.map((word) => ({
+      ...word,
+      startTime: word.startTime + offsetMs,
+      endTime: word.endTime + offsetMs,
+    })),
+  }));
+};
+
+/**
  * 获取元素的文本内容，跳过指定角色
  * @param node 节点
  * @param skipRoles 跳过的角色集合


### PR DESCRIPTION
- parseTTML: 新增 extractTtmlLyricOffsetMs 和 applyLyricOffsetToLines
- IPlaybackEngine: 新增 getChannels() 可选方法
- FFmpegAudioPlayer/AudioElementPlayer/MpvPlayer: 实现 getChannels()
- MpvPlayer: 监听 audio-params/channel-count 获取声道数
- MpvService: 观察 audio-params/channel-count 属性
- AudioManager: 暴露 getChannels() 方法
- status store: 新增 currentAudioChannels 状态
- LyricManager: TTML 偏移仅在6声道时应用，修复预加载缓存时序
- PlayerController: canplay 时更新声道数，声道变化时自动重载歌词