### PR TITLE
🐞 fix: 补充延迟补偿应用逻辑

### DIFF
--- a/src/core/audio-player/AudioElementPlayer.ts
+++ b/src/core/audio-player/AudioElementPlayer.ts
@@ -196,11 +196,12 @@ export class AudioElementPlayer extends BaseAudioPlayer {
     if (this.isInternalSeeking) {
       return this.targetSeekTime;
     }
-    // 基础时间 - 自动延迟补偿 + 手动延迟补偿
+    // 基础时间 - 自动延迟补偿 + 手动延迟补偿 （仅 playback 模式生效）
+    const finalCompensation = this.audioCtx?.latencyHint === 'playback' ? this.audioDelayCompensation / 1000 : 0;
     return (
       (this.audioElement.currentTime || 0) -
       this.compensatedLatency +
-      this.audioDelayCompensation / 1000
+      finalCompensation
     );
   }
 

--- a/src/core/audio-player/AudioElementPlayer.ts
+++ b/src/core/audio-player/AudioElementPlayer.ts
@@ -197,7 +197,7 @@ export class AudioElementPlayer extends BaseAudioPlayer {
       return this.targetSeekTime;
     }
     // 基础时间 - 自动延迟补偿 + 手动延迟补偿 （仅 playback 模式生效）
-    const finalCompensation = this.audioCtx?.latencyHint === 'playback' ? this.audioDelayCompensation / 1000 : 0;
+    const finalCompensation = useSettingStore().audioLatencyHint === 'playback' ? this.audioDelayCompensation / 1000 : 0;
     return (
       (this.audioElement.currentTime || 0) -
       this.compensatedLatency +


### PR DESCRIPTION
- 对 #958 的补充提交：
  - 加入一个三元运算逻辑，当 Web Audio 的输出模式为 interactive 时临时取消 audioDelayCompensation 的值，防止 playback 模式设置的值影响 interactive 模式导致音频与歌词进度错误；
  - 当切换回 playback 模式后，此前设置的值 audioDelayCompensation 不会丢失。