### PR TITLE
🐞 fix: 修复延迟补偿在playback模式意外丢失补偿值的逻辑bug

### DIFF
--- a/src/core/audio-player/AudioElementPlayer.ts
+++ b/src/core/audio-player/AudioElementPlayer.ts
@@ -5,6 +5,7 @@ import {
   type AudioEventType,
 } from "./BaseAudioPlayer";
 import type { EngineCapabilities } from "./IPlaybackEngine";
+import { useSettingStore } from "@/stores";
 
 /**
  * 基于 HTMLAudioElement 的播放器实现
@@ -196,11 +197,21 @@ export class AudioElementPlayer extends BaseAudioPlayer {
     if (this.isInternalSeeking) {
       return this.targetSeekTime;
     }
+    const settingStore = useSettingStore();
+
+    const isPlayback = settingStore.audioLatencyHint === "playback";
+
+    let autoLatency = 0;
+
+    if (isPlayback && this.audioCtx) {
+      autoLatency = (this.audioCtx.outputLatency || 0) + (this.audioCtx.baseLatency || 0);
+    }
+    const manualCompensation = isPlayback ? this.audioDelayCompensation / 1000 : 0;
     // 基础时间 - 自动延迟补偿 + 手动延迟补偿
     return (
       (this.audioElement.currentTime || 0) -
-      this.compensatedLatency +
-      this.audioDelayCompensation / 1000
+      autoLatency +
+      manualCompensation
     );
   }
 


### PR DESCRIPTION
- 对 #958 和#990 的补充提交：
  - 修复两个问题：
    - `playback`模式下设置的`audioDelayCompensation`值被意外计算在`interactive`模式下，当`audioDelayCompensation`的值不为0时导致`interactive`模式歌词与歌词进度不一致；
    - 从`interactive`切换到`playback`模式后，自动计算的延迟补偿被意外设定为0导致自动补偿失效。