### PR TITLE
refactor(lyricParser): 修正并移动 alignLocalLyrics

### DIFF
--- a/src/core/player/LyricManager.ts
+++ b/src/core/player/LyricManager.ts
@@ -9,6 +9,7 @@ import { isElectron } from "@/utils/env";
 import { applyBracketReplacement } from "@/utils/lyric/lyricFormat";
 import { applyProfanityUncensor } from "@/utils/lyric/lyricProfanity";
 import {
+  alignLyricLines,
   alignLyrics,
   isWordLevelFormat,
   parseQRCLyric,
@@ -108,48 +109,6 @@ class LyricManager {
     } catch (error) {
       console.error("写入歌词缓存失败:", error);
     }
-  }
-
-  /**
-   * 对齐本地歌词
-   * @param lyricData 本地歌词数据
-   * @returns 对齐后的本地歌词数据
-   */
-  private alignLocalLyrics(lyricData: SongLyric): SongLyric {
-    // 同一时间的两/三行分别作为主句、翻译、音译
-    const toTime = (line: LyricLine) => Number(line?.startTime ?? line?.words?.[0]?.startTime ?? 0);
-    // 获取结束时间
-    const toEndTime = (line: LyricLine) =>
-      Number(line?.endTime ?? line?.words?.[line?.words?.length - 1]?.endTime ?? 0);
-    // 取内容
-    const toText = (line: LyricLine) => String(line?.words?.[0]?.word || "").trim();
-    const lrc = lyricData.lrcData || [];
-    if (!lrc.length) return lyricData;
-    // 按开始时间分组，时间差 < 0.6s 视为同组
-    const sorted = [...lrc].sort((a, b) => toTime(a) - toTime(b));
-    const groups: LyricLine[][] = [];
-    for (const line of sorted) {
-      const st = toTime(line);
-      const last = groups[groups.length - 1]?.[0];
-      if (last && Math.abs(st - toTime(last)) < 0.6) groups[groups.length - 1].push(line);
-      else groups.push([line]);
-    }
-    // 组装：第 1 行主句；第 2 行翻译；第 3 行音译；不调整时长
-    const aligned = groups.map((group) => {
-      const base = { ...group[0] } as LyricLine;
-      const tran = group[1];
-      const roma = group[2];
-      if (!base.translatedLyric && tran) {
-        base.translatedLyric = toText(tran);
-        base.endTime = Math.max(toEndTime(base), toEndTime(tran));
-      }
-      if (!base.romanLyric && roma) {
-        base.romanLyric = toText(roma);
-        base.endTime = Math.max(toEndTime(base), toEndTime(roma));
-      }
-      return base;
-    });
-    return { lrcData: aligned, yrcData: lyricData.yrcData };
   }
 
   /**
@@ -478,7 +437,7 @@ class LyricManager {
         };
       }
       // 普通格式
-      let aligned = this.alignLocalLyrics({ lrcData: parsedLines, yrcData: [] });
+      let aligned: SongLyric = { lrcData: alignLyricLines(parsedLines), yrcData: [] };
       let usingQRCLyric = false;
       // 如果开启了本地歌曲 QQ 音乐匹配，尝试获取逐字歌词
       if (settingStore.localLyricQQMusicMatch && song) {
@@ -806,11 +765,8 @@ class LyricManager {
           if (isWordLevelFormat(format)) {
             result.yrcData = lines;
           } else {
-            result.lrcData = lines;
             // 应用翻译对齐逻辑
-            const aligned = this.alignLocalLyrics(result);
-            result.lrcData = aligned.lrcData;
-            result.yrcData = aligned.yrcData;
+            result.lrcData = alignLyricLines(lines);
           }
         }
       }
@@ -887,7 +843,7 @@ class LyricManager {
         const overrideResult = await this.fetchLocalOverrideLyric(song.id);
         if (!isEmpty(overrideResult.data.lrcData) || !isEmpty(overrideResult.data.yrcData)) {
           // 对齐
-          overrideResult.data = this.alignLocalLyrics(overrideResult.data);
+          overrideResult.data.lrcData = alignLyricLines(overrideResult.data.lrcData);
           fetchResult = overrideResult;
         } else if (song.path) {
           // 本地文件

--- a/src/utils/lyric/lyricParser.ts
+++ b/src/utils/lyric/lyricParser.ts
@@ -304,14 +304,14 @@ export const alignLyrics = (
  * 根据开始时间将同一时间的多行歌词分为一组，第一行作为主句，第二行作为翻译，第三行作为音译
  * @param lyrics 未设置翻译和音译的歌词数据
  * @param endTime 对齐时如何处理附加行的结束时间（忽略、匹配、设为最大值）
- * @param maxTimeDiff 允许匹配的最大时间差（单位：秒），超过该时间差的行将不会被视为同一行
+ * @param maxTimeDiff 允许匹配的最大时间差（单位：毫秒），超过该时间差的行将不会被视为同一行
  * @returns 对齐后的歌词数据
  */
 export const alignLyricLines = (
   lyrics: LyricLine[],
   {
     endTime = "set",
-    maxTimeDiff = 0.6,
+    maxTimeDiff = 0, // 默认严格匹配
   }: Partial<{
     endTime: "ignore" | "match" | "set";
     maxTimeDiff: number;

--- a/src/utils/lyric/lyricParser.ts
+++ b/src/utils/lyric/lyricParser.ts
@@ -300,6 +300,89 @@ export const alignLyrics = (
 };
 
 /**
+ * 对齐歌词的翻译和音译
+ * 根据开始时间将同一时间的多行歌词分为一组，第一行作为主句，第二行作为翻译，第三行作为音译
+ * @param lyrics 未设置翻译和音译的歌词数据
+ * @param endTime 对齐时如何处理附加行的结束时间（忽略、匹配、设为最大值）
+ * @param maxTimeDiff 允许匹配的最大时间差（单位：秒），超过该时间差的行将不会被视为同一行
+ * @returns 对齐后的歌词数据
+ */
+export const alignLyricLines = (
+  lyrics: LyricLine[],
+  {
+    endTime = "set",
+    maxTimeDiff = 0.6,
+  }: Partial<{
+    endTime: "ignore" | "match" | "set";
+    maxTimeDiff: number;
+  }> = {},
+): LyricLine[] => {
+  if (!lyrics.length) return [];
+  // 获取开始时间
+  const toStartTime = (line: LyricLine) =>
+    Number(line?.startTime ?? line?.words?.[0]?.startTime ?? 0);
+  // 获取结束时间
+  const toEndTime = (line: LyricLine) =>
+    Number(line?.endTime ?? line?.words?.[line?.words?.length - 1]?.endTime ?? 0);
+  // 取内容
+  const toText = (line: LyricLine) => String(line?.words?.map((w) => w.word).join("") || "").trim();
+  // 是否匹配
+  const isTimeMatch = (baseLine: LyricLine | undefined, addLine: LyricLine | undefined) => {
+    if (!baseLine || !addLine) return false;
+    const timeDiff = Math.abs(toStartTime(baseLine) - toStartTime(addLine));
+    if (timeDiff > maxTimeDiff) return false;
+    if (endTime === "match") {
+      const endTimeDiff = Math.abs(toEndTime(baseLine) - toEndTime(addLine));
+      if (endTimeDiff > maxTimeDiff) return false;
+    }
+    return true;
+  };
+  // 按开始时间分组
+  const sorted = [...lyrics].sort((a, b) => toStartTime(a) - toStartTime(b));
+  const groups: LyricLine[][] = [];
+  for (const line of sorted) {
+    const last = groups[groups.length - 1]?.[0];
+    if (isTimeMatch(last, line)) groups[groups.length - 1].push(line);
+    else groups.push([line]);
+  }
+  // 合并附加行
+  const mergeAddLine = (
+    baseLine: LyricLine,
+    addLine: LyricLine | undefined,
+    key: "translatedLyric" | "romanLyric",
+  ) => {
+    if (baseLine[key] || !addLine) return;
+    const addText = toText(addLine);
+    if (!addText) return;
+    baseLine[key] = addText;
+    // 如果需要设置主行的结束时间，则将主行的结束时间设置为主行和附加行结束时间的较大值
+    if (endTime !== "set") return;
+    const oldEndTime = toEndTime(baseLine);
+    const addEndTime = toEndTime(addLine);
+    if (!Number.isFinite(addEndTime) || addEndTime <= oldEndTime) return;
+    baseLine.endTime = addEndTime;
+    // 考虑句中最后一个字的结束时间
+    if (baseLine.words?.length) {
+      const lastWord = baseLine.words[baseLine.words.length - 1];
+      const lastWordEndTime = lastWord.endTime;
+      if (lastWordEndTime === oldEndTime) {
+        lastWord.endTime = addEndTime;
+      }
+    }
+  };
+  // 组装：第 1 行主句；第 2 行翻译；第 3 行音译；其余行舍去
+  const aligned = groups.map((group) => {
+    const base = { ...group[0] } as LyricLine;
+    const tran = group[1];
+    const roma = group[2];
+    mergeAddLine(base, tran, "translatedLyric");
+    mergeAddLine(base, roma, "romanLyric");
+    return base;
+  });
+  return aligned;
+};
+
+/**
  * 解析 QRC 内容为行数据
  */
 const parseQRCContent = (


### PR DESCRIPTION
将 LyricManager 的 alignLocalLyrics 移动到了 lyricParser 并重命名为 alignLyricLines

修了一下，使之考虑了逐字歌词，设置结束时间时也考虑 `words`；增加了两个参数 `endTime` 和 `maxTimeDiff` 用于指定是否考虑结束时间和允许的时间差

同时修复了 alignLyricLines 注释中的单位错误，更改 maxTimeDiff 默认值为 0（0.6 ms 没必要比了，直接 0 吧）