### PR TITLE
style(SongWiki): 修复了一些样式问题

### DIFF
--- a/src/views/Song/wiki.vue
+++ b/src/views/Song/wiki.vue
@@ -8,17 +8,14 @@
               :src="currentSong.cover"
               class="cover-img"
               object-fit="cover"
+              :previewed-img-props="{ style: { borderRadius: '8px' } }"
               :render-toolbar="renderToolbar"
-              :img-props="{
-                style: { width: '100%', height: '100%', borderRadius: '8px' },
-                alt: 'detail-cover',
-              }"
             />
             <n-image
               class="cover-shadow"
               preview-disabled
               :src="currentSong.cover"
-              :img-props="{ alt: 'cover-shadow' }"
+              object-fit="cover"
             />
           </div>
           <div class="data">
@@ -546,12 +543,17 @@ onActivated(() => {
       flex-shrink: 0;
       margin-right: 20px;
       position: relative;
+      :deep(img) {
+        width: 100%;
+        height: 100%;
+      }
       .cover-img {
         position: relative;
         z-index: 1;
         border-radius: 8px;
         width: 100%;
         height: 100%;
+        overflow: hidden;
       }
       .cover-shadow {
         position: absolute;


### PR DESCRIPTION
1. 当歌曲封面不是正方形时，封面背板（`cover-shadow`）显示错误
2. 为点击查看封面预览也设置了圆角，与 `ListDetail` 保持一致